### PR TITLE
Added -root flag support

### DIFF
--- a/src/handlers.go
+++ b/src/handlers.go
@@ -172,8 +172,8 @@ func send(rw http.ResponseWriter, name string, title string, context interface{}
 	}
 	fmt.Fprintln(rw,
 		mustache.RenderFileInLayout(
-			"template/"+name+".html",
-			"template/layout.html",
+			maudRoot+"/template/"+name+".html",
+			maudRoot+"/template/layout.html",
 			struct {
 				Info  SiteInfo
 				Title string
@@ -189,8 +189,8 @@ func sendError(rw http.ResponseWriter, code int, context interface{}) {
 	rw.WriteHeader(code)
 	fmt.Fprintln(rw,
 		mustache.RenderFileInLayout(
-			"errors/"+strconv.Itoa(code)+".html",
-			"errors/layout.html",
+			maudRoot+"/errors/"+strconv.Itoa(code)+".html",
+			maudRoot+"/errors/layout.html",
 			struct {
 				Info SiteInfo
 				Data interface{}

--- a/src/main.go
+++ b/src/main.go
@@ -7,23 +7,35 @@ import (
 	"github.com/gorilla/mux"
 	"io/ioutil"
 	"net/http"
+	"os"
+	"path/filepath"
 )
 
 var siteInfo SiteInfo
+// absolute path to Maud root directory
+var maudRoot string
 
 func main() {
+	// get executable path
+	maudExec, err := filepath.Abs(os.Args[0])
+	if err != nil {
+		panic(err)
+	}
+	maudRoot = filepath.Dir(maudExec)
+
 	// Command line parameters
 	bind := flag.String("port", ":8080", "Address to bind to")
 	mongo := flag.String("dburl", "localhost", "MongoDB servers, separated by comma")
 	dbname := flag.String("dbname", "maud", "MongoDB database to use")
+	flag.StringVar(&maudRoot, "root", maudRoot, "The HTTP server root directory")
 	flag.Parse()
 
 	// Seed RNG
 	seedRand()
 
 	// Load Site info file
-	rawconf, _ := ioutil.ReadFile("info.json")
-	err := json.Unmarshal(rawconf, &siteInfo)
+	rawconf, _ := ioutil.ReadFile(maudRoot + "/info.json")
+	err = json.Unmarshal(rawconf, &siteInfo)
 	if err != nil {
 		panic(err)
 	}
@@ -47,9 +59,9 @@ func main() {
 	POST.HandleFunc("/thread/{thread}/reply", apiReply)
 
 	http.Handle("/", router)
-	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir("static"))))
+	http.Handle("/static/", http.StripPrefix("/static/", http.FileServer(http.Dir(maudRoot+"/static"))))
 
 	// Start serving pages
-	fmt.Printf("Listening on %s\r\n", *bind)
+	fmt.Printf("Listening on %s\r\nServer root: %s\r\n", *bind, maudRoot)
 	http.ListenAndServe(*bind, nil)
 }


### PR DESCRIPTION
Not sure if useful, but I had nothing better to do...feel free to tell me it's BS:

I added a command line flag `-root <rootdir>` which can be specified when invoking
the maud executable to change the server root.
Also, the default server root is now set to the dirname of the maud executable instead
of the directory which you launch the server from, so a `../maud` will set the root dir to `..`, not `.`
(in other words, you can launch the server from wherever you want...yeah, no big advantage).

(uso l'inglese per abitudine, se preferisci l'italiano dimmelo)
