### PR TITLE
small fix to dates.coffee

### DIFF
--- a/static/src/coffee/dates.coffee
+++ b/static/src/coffee/dates.coffee
@@ -7,6 +7,7 @@ format = (date) ->
     return fulldate + " " + fullhour
 
 sincetime = (diff) ->
+    return "just now" if diff < 1
     int = Math.floor(diff/86400)
     return int + " "+plur("day",int)+" ago" if int > 0
     int = Math.floor(diff/3600)


### PR DESCRIPTION
In rare cases, diff may be negative in dates (so a "-1 seconds ago" may be printed);
a simple check in dates.coffee easily prevents this misbehaviour.
