### PR TITLE
Change .spoiler color from black to gray

### DIFF
--- a/static/src/scss/screen.scss
+++ b/static/src/scss/screen.scss
@@ -146,8 +146,8 @@ h2 { font-size: 1.3em; margin: 0; padding: 0; }
 
 /* blockquote { margin: 0; padding: 0; p { color: #cae; } } */
 span.spoiler {
-    background-color: #000; color: #000;
-    &:hover { color: #fff; }
+    background-color: #555; color: #555;
+    &:hover { color: inherit; background-color: inherit; }
 }
 
 /* Homepage */


### PR DESCRIPTION
Ciao, ti propongo un'altra mini-modifica; avevo provato anch'io con gli spoiler e ho notato che farli in nero li rende a malapena leggibili, per cui magari vale la pena farli in grigio (per rimanere a tema ;) ); inoltre mettendo le proprietà onhover a "inherit" il testo diventa uguale a quello non spoilerato senza dover cambiare nulla nel caso il secondo cambiasse (questa è una sottigliezza, vedi tu se adottarla o meno, la cosa principale è il colore spoilerato).

Ne approfitto per chiederti: il bbcode parser è completo? (Ho visto il codice, bel lavoro btw)
Quando pensi si possa fare il merge del markdown?
