### PR TITLE
Allow editing tags while editing OP

### DIFF
--- a/src/database.go
+++ b/src/database.go
@@ -246,6 +246,20 @@ func DBIncTag(name string, lastThread bson.ObjectId) error {
 	return err
 }
 
+// DBDecTag updates the tag named `name` by decreasing its number of
+// posts by 1. LastThread remains the old one.
+func DBDecTag(name string) error {
+	inc := mgo.Change{
+		Update: bson.M{
+			"$inc": bson.M{"posts": -1},
+		},
+		ReturnNew: true,
+	}
+	var doc Tag
+	_, err := database.C("tags").Find(bson.M{"name": name}).Apply(inc, &doc)
+	return err
+}
+
 // DBEditPost updates the post with id `id` by changing its content to
 // newContent and its lastmodified date to the current date.
 func DBEditPost(id bson.ObjectId, newContent string) error {
@@ -254,6 +268,15 @@ func DBEditPost(id bson.ObjectId, newContent string) error {
 			"lastmodified": time.Now().UTC().Unix(),
 			"content":      newContent,
 		},
+	})
+	return err
+}
+
+// DBSetThreadTags changes the tags of the thread with id `id` to `newTags`
+// and returns an error, or nil if no error occurred
+func DBSetThreadTags(id bson.ObjectId, newTags []string) error {
+	err := database.C("threads").UpdateId(id, bson.M{
+		"$set": bson.M{"tags": newTags},
 	})
 	return err
 }

--- a/src/database.go
+++ b/src/database.go
@@ -257,6 +257,10 @@ func DBDecTag(name string) error {
 	}
 	var doc Tag
 	_, err := database.C("tags").Find(bson.M{"name": name}).Apply(inc, &doc)
+	// remove tag if not referred by any thread.
+	if doc.Posts < 1 {
+		err = database.C("tags").Remove(bson.M{"name": name})
+	}
 	return err
 }
 

--- a/static/src/coffee/posts.coffee
+++ b/static/src/coffee/posts.coffee
@@ -3,12 +3,12 @@ original = []
 # post edit
 editPost = (id) ->
     if id == 0
-      pid = type = "thread"
-      idname = "OP"
+        pid = type = "thread"
+        idname = "OP"
     else
-      pid = "p#{id}"
-      type = "post"
-      idname = "##{id}"
+        pid = "p#{id}"
+        type = "post"
+        idname = "##{id}"
     post = document.getElementById pid
     content = "Retrieving content..."
     qwest.post(window.stripPage(location.pathname) + "/post/" + id + "/raw")
@@ -24,6 +24,11 @@ editPost = (id) ->
             section.insertBefore errmsg, section.firstChild
     nick = document.querySelector("##{pid}  .nickname").innerHTML
     tripcodebar = if !window.adminMode then "<input class=\"full short inline verysmall\" type=\"text\" name=\"tripcode\" placeholder=\"Tripcode (required)\" required />" else ""
+    # if post is OP, allow editing thread tags
+    tagsbar = ""
+    tags = post.dataset?.tags
+    if idname is "OP" and tags.replace(/// ///g, '').length > 0
+        tagsbar = "<input class=\"full small\" type=\"text\" name=\"tags\" placeholder=\"Tags (separated by comma)\" value=\"#{tags.substring(0, tags.length-2)}\"/>"
     original[id] = post.innerHTML
     post.innerHTML = """
 <section id="#{id}" class="form"><a name="edit" class="nolink"></a>
@@ -34,6 +39,7 @@ editPost = (id) ->
       <span style="color: #ccc; display: inline-block; width: auto; font-size: 0.9em;">editing #{idname}</span>
     </div>
     <textarea class="full small editor" name="text" required placeholder="Thread text (Markdown is supported)">#{content}</textarea>
+    #{tagsbar}
     <center>
       <div class="chars-count" data-maxlen="#{maxlen}"></div>
       <input type="Submit" value="Edit post"/><button type="button" onclick="cancelForm(#{id});">Cancel</button>
@@ -46,12 +52,12 @@ editPost = (id) ->
 # post delete
 deletePost = (id) ->
     if id == 0
-      pid = type = "thread"
-      idname = "OP"
+        pid = type = "thread"
+        idname = "OP"
     else
-      pid = "p#{id}"
-      type = "post"
-      idname = "##{id}"
+        pid = "p#{id}"
+        type = "post"
+        idname = "##{id}"
     post = document.getElementById pid
     nick = document.querySelector("##{pid}  .nickname").innerHTML
     original[id] = post.innerHTML

--- a/template/thread.html
+++ b/template/thread.html
@@ -8,7 +8,7 @@
 <section class="tags">
 {{#Tags}}<a href="{{BasePath}}tag/{{.}}" class="tag">#{{.}}</a> {{/Tags}}
 </section>
-<article class="thread" id="thread">
+<article class="thread" id="thread" data-tags="{{#Tags}}#{{.}}, {{/Tags}}">
     <h2 class="thread-title">{{Title}}</h2>
     {{/Thread}}
     {{#HasOP}}


### PR DESCRIPTION
Volendo da ottimizzare la parte web: non mandare il parametro "tags" nel POST se non si sono modificate le tag (così si evita che il server riprocessa quella parte)