### PR TITLE
automatically nest tags with editor

### DIFF
--- a/static/src/coffee/editor.coffee
+++ b/static/src/coffee/editor.coffee
@@ -1,7 +1,8 @@
 editorAdd = (elem, tag) ->
-	txt = elem.parentElement.parentElement.text
-	txt.value += "[#{tag}][/#{tag}]"
-	txt.selectionStart = txt.selectionEnd = txt.value.length - 3 - tag.length
-	txt.focus()
+    txt = elem.parentElement.parentElement.text
+    cursor = txt.selectionStart
+    txt.value = txt.value[0..txt.selectionStart-1] + "[#{tag}][/#{tag}]" + txt.value[txt.selectionStart..]
+    txt.selectionStart = txt.selectionEnd = cursor + tag.length + 2
+    txt.focus()
 
 window.editorAdd = editorAdd


### PR DESCRIPTION
Ti propongo 'sta modifichina: nell'editor inserisco la tag dove c'è il cursore, in modo che se uno nidifica più tag, non ha bisogno di spostare il cursore ogni volta com'è attualmente.
(Inoltre, per mantenere la convenzione con gli altri coffeescript, ho sostituito la tab con 4 spazi. Personalmente non sono un fan dell'indentazione a spazi, e se mi dici "usiamo la tab (da 8 spazi magari) in tutti gli script" com'è in Go, io sono d'accordissimo. L'importante comunque è mantenere la stessa convenzione (così non devo modificare le impostazioni di Vim ogni volta :P))