### PR TITLE
should fix the tagsearch

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -249,7 +249,7 @@ func apiTagSearch(rw http.ResponseWriter, req *http.Request) {
 		basepath = val.BasePath
 	}
 
-	http.Redirect(rw, req, basepath+"tag/"+sanitizeURL(tags), http.StatusMovedPermanently)
+	http.Redirect(rw, req, basepath+"tag/"+strings.ToLower(tags), http.StatusMovedPermanently)
 }
 
 // apiGetRaw: retreive the raw content of a post.

--- a/src/bbcode.go
+++ b/src/bbcode.go
@@ -33,10 +33,6 @@ func initbbcode() {
 		if !strings.HasPrefix(par, "http://") && !strings.HasPrefix(par, "https://") {
 			par = "http://" + par
 		}
-		idx := strings.IndexRune(con, '?')
-		if idx > 0 {
-			par = par[0:idx] + url.QueryEscape(par[idx:])
-		}
 		return "<a href=\"" + par + "\">" + con + "</a>"
 	}
 	bbElements["spoiler"] = func(_, con string) string {

--- a/src/database.go
+++ b/src/database.go
@@ -3,7 +3,6 @@ package main
 import (
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
-	"html"
 	"sort"
 	"strings"
 	"time"
@@ -107,7 +106,6 @@ func DBReplyThread(thread *Thread, user User, content string) (int, error) {
 // the `tag` string.
 func DBGetThreadList(tag string, limit, offset int, filter []string) ([]Thread, error) {
 	var filterByTag bson.M
-	tag = html.UnescapeString(tag)
 	if tag != "" {
 		if idx := strings.IndexRune(tag, ','); idx > 0 {
 			// tag1,tag2,... means 'union'

--- a/src/main.go
+++ b/src/main.go
@@ -23,8 +23,8 @@ func setupHandlers(router *mux.Router, isAdmin, isSubdir bool) {
 	POST := router.Methods("POST").Subrouter()
 
 	SetHandler(GET, "/", httpHome, isAdmin, isSubdir)
-	SetHandler(GET, "/tag/{tag}", httpTagSearch, isAdmin, isSubdir)
 	SetHandler(GET, "/tag/{tag}/page/{page}", httpTagSearch, isAdmin, isSubdir)
+	SetHandler(GET, "/tag/{tag:.*}", httpTagSearch, isAdmin, isSubdir)
 	SetHandler(GET, "/thread/{thread}", httpThread, isAdmin, isSubdir)
 	SetHandler(GET, "/thread/{thread}/page/{page}", httpThread, isAdmin, isSubdir)
 	SetHandler(GET, "/new", httpNewThread, isAdmin, isSubdir)

--- a/src/utils.go
+++ b/src/utils.go
@@ -179,11 +179,3 @@ func filterFromCookie(req *http.Request) []string {
 func isLightVersion(req *http.Request) bool {
 	return len(siteInfo.LightVersionDomain) > 0 && req.Host == siteInfo.LightVersionDomain
 }
-
-func sanitizeURL(tags string) string {
-	// replace all characters which are dangerous in an URL
-	sane := strings.Replace(tags, "/", "&sol;", -1)
-	sane = strings.Replace(sane, "#", "&num;", -1)
-	sane = strings.Replace(sane, "?", "&quest;", -1)
-	return sane
-}

--- a/template/thread.html
+++ b/template/thread.html
@@ -6,11 +6,11 @@
 <div class="pages" data-current="{{Page}}" data-max="{{MaxPages}}"></div>
 {{#Thread}}
 <section class="tags">
-{{#Tags}}<a href="{{BasePath}}tag/{{.}}" class="tag">#{{.}}</a> {{/Tags}}
+{{#Tags}}<a href="{{BasePath}}tag/{{.}}" class="tag">#{{.}}</a>{{/Tags}}
 </section>
 <article class="thread" id="thread" data-tags="{{#Tags}} #{{.}}{{/Tags}}">
     <h2 class="thread-title">{{Title}}</h2>
-    {{/Thread}}
+{{/Thread}}
     {{#HasOP}}
     {{#ThreadPost}}
     {{#Data}}


### PR DESCRIPTION
Ti propongo questa soluzione per la tagsearch con i tag contenenti slash:
ho levato la sanitizzazione del tagsearch e ho cambiato le regole del router in modo che se dopo il /tag/ non c'è /page/{num} considera tutto il resto come nome della tag (come fa wikipedia, es: http://en.wikipedia.org/wiki/GNU/Linux). Mi sembra che funzioni, ma testa bene anche te, io ho fatto solo prove in locale.
Inoltre ho levato il queryescape all'url (onestamente non ricordo proprio perché l'avessi messo), dovrebbe fixare anche #48.