### PR TITLE
merge tag filter and thread hiding

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -361,11 +361,7 @@ func apiGetRaw(rw http.ResponseWriter, req *http.Request) {
 // POST params: tag
 func apiTagList(rw http.ResponseWriter, req *http.Request) {
 	tag := req.PostFormValue("tag")
-	_, hTags, err := getHiddenElems(req)
-	if err != nil {
-		sendError(rw, 500, err.Error())
-		return
-	}
+	_, hTags := getHiddenElems(req)
 	tags, err := db.GetMatchingTags(tag, 0, 0, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())

--- a/src/api.go
+++ b/src/api.go
@@ -361,7 +361,12 @@ func apiGetRaw(rw http.ResponseWriter, req *http.Request) {
 // POST params: tag
 func apiTagList(rw http.ResponseWriter, req *http.Request) {
 	tag := req.PostFormValue("tag")
-	tags, err := db.GetMatchingTags(tag, 0, 0, filterFromCookie(req))
+	_, hTags, err := getHiddenElems(req)
+	if err != nil {
+		sendError(rw, 500, err.Error())
+		return
+	}
+	tags, err := db.GetMatchingTags(tag, 0, 0, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
 		return

--- a/src/database.go
+++ b/src/database.go
@@ -196,6 +196,20 @@ func (db Database) GetThreads(surl []string, limit, offset int) ([]Thread, error
 	return threads, err
 }
 
+// GetTags returns the list of specified tags
+func (db Database) GetTags(tagnames []string, limit, offset int) ([]Tag, error) {
+	var tags []Tag
+	query := db.database.C("tags").Find(bson.M{"name": bson.M{"$in": tagnames}})
+	if offset > 0 {
+		query = query.Skip(offset)
+	}
+	if limit > 0 {
+		query = query.Limit(limit)
+	}
+	err := query.All(&tags)
+	return tags, err
+}
+
 func (db Database) GetThreadById(id bson.ObjectId) (Thread, error) {
 	var thread Thread
 	err := db.database.C("threads").FindId(id).One(&thread)

--- a/src/handlers.go
+++ b/src/handlers.go
@@ -15,9 +15,8 @@ import (
 )
 
 func httpHome(rw http.ResponseWriter, req *http.Request) {
-	// TODO: incorporate this filter into crHidden cookie.
-	filter := filterFromCookie(req)
-	tags, err := db.GetPopularTags(siteInfo.HomeTagsNum, 0, filter)
+	hThreads, hTags, _ := getHiddenElems(req)
+	tags, err := db.GetPopularTags(siteInfo.HomeTagsNum, 0, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
 		return
@@ -52,7 +51,7 @@ func httpHome(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	tinfos, err := retreiveThreads(siteInfo.HomeThreadsNum, 0, req, filter)
+	tinfos, err := retreiveThreads(siteInfo.HomeThreadsNum, 0, hThreads, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
 		return
@@ -84,7 +83,8 @@ func httpAllThreads(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	tinfos, err := retreiveThreads(siteInfo.ThreadsPerPage, pageOffset, req, filterFromCookie(req))
+	hThreads, hTags, _ := getHiddenElems(req)
+	tinfos, err := retreiveThreads(siteInfo.ThreadsPerPage, pageOffset, hThreads, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
 		return
@@ -122,7 +122,8 @@ func httpAllTags(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	tags, err := db.GetPopularTags(siteInfo.TagsPerPage, pageOffset, filterFromCookie(req))
+	_, hTags, _ := getHiddenElems(req)
+	tags, err := db.GetPopularTags(siteInfo.TagsPerPage, pageOffset, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
 		return
@@ -275,7 +276,8 @@ func httpTagSearch(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	threads, err := db.GetThreadList(tagName, siteInfo.TagResultsPerPage, pageOffset, filterFromCookie(req))
+	hThreads, hTags, _ := getHiddenElems(req)
+	threads, err := db.GetThreadList(tagName, siteInfo.TagResultsPerPage, pageOffset, hThreads, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
 		return
@@ -443,9 +445,9 @@ func httpManageHidden(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	hiddenThreads, err := getHiddenElems(req)
+	hThreads, _, err := getHiddenElems(req)
 
-	threads, err := db.GetThreads(hiddenThreads, siteInfo.ThreadsPerPage, pageOffset)
+	threads, err := db.GetThreads(hThreads, siteInfo.ThreadsPerPage, pageOffset)
 	if err != nil {
 		sendError(rw, 500, err.Error())
 		return

--- a/src/handlers.go
+++ b/src/handlers.go
@@ -15,7 +15,7 @@ import (
 )
 
 func httpHome(rw http.ResponseWriter, req *http.Request) {
-	hThreads, hTags, _ := getHiddenElems(req)
+	hThreads, hTags := getHiddenElems(req)
 	tags, err := db.GetPopularTags(siteInfo.HomeTagsNum, 0, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
@@ -83,7 +83,7 @@ func httpAllThreads(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	hThreads, hTags, _ := getHiddenElems(req)
+	hThreads, hTags := getHiddenElems(req)
 	tinfos, err := retreiveThreads(siteInfo.ThreadsPerPage, pageOffset, hThreads, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
@@ -122,7 +122,7 @@ func httpAllTags(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	_, hTags, _ := getHiddenElems(req)
+	_, hTags := getHiddenElems(req)
 	tags, err := db.GetPopularTags(siteInfo.TagsPerPage, pageOffset, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
@@ -276,7 +276,7 @@ func httpTagSearch(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	hThreads, hTags, _ := getHiddenElems(req)
+	hThreads, hTags := getHiddenElems(req)
 	threads, err := db.GetThreadList(tagName, siteInfo.TagResultsPerPage, pageOffset, hThreads, hTags)
 	if err != nil {
 		sendError(rw, 500, err.Error())
@@ -445,7 +445,7 @@ func httpManageHidden(rw http.ResponseWriter, req *http.Request) {
 		pageOffset = 0
 	}
 
-	hThreads, _, err := getHiddenElems(req)
+	hThreads, _ := getHiddenElems(req)
 
 	threads, err := db.GetThreads(hThreads, siteInfo.ThreadsPerPage, pageOffset)
 	if err != nil {

--- a/src/utils.go
+++ b/src/utils.go
@@ -53,6 +53,7 @@ func parseContent(content, ctype string) string {
 }
 
 func parseTags(tags string) []string {
+	tags = strings.Replace(tags, "&", "", -1)
 	if len(tags) < 1 {
 		return nil
 	}
@@ -208,17 +209,14 @@ func strdate(unixtime int64) string {
 // getHiddenElems checks if the request contains a cookie 'crHidden'
 // and parses its value, returning a slice with hidden threads and
 // hidden tags.
-// If no cookie exists, or its value is invalid, err != nil is returned.
-func getHiddenElems(req *http.Request) ([]string, []string, error) {
+func getHiddenElems(req *http.Request) (threads, tags []string) {
 	if cookie, err := req.Cookie("crHidden"); err == nil {
 		// cookie value has the format: "url1&url2&tag1&..."
 		val, err := url.QueryUnescape(cookie.Value)
 		if err != nil {
-			return nil, nil, err
+			return
 		}
 		splitted := strings.Split(val, "&")
-		threads := make([]string, 0)
-		tags := make([]string, 0)
 		for _, s := range splitted {
 			if len(s) < 1 {
 				continue
@@ -229,15 +227,14 @@ func getHiddenElems(req *http.Request) ([]string, []string, error) {
 				threads = append(threads, s)
 			}
 		}
-		return threads, tags, err
+		return
 	} else {
 		// cookie not present
-		return nil, nil, err
+		return
 	}
 }
 
 func retreiveThreads(n, offset int, hThreads, hTags []string) ([]ThreadInfo, error) {
-
 	threads, err := db.GetThreadList("", n, offset, hThreads, hTags)
 	if err != nil {
 		return nil, err

--- a/src/utils.go
+++ b/src/utils.go
@@ -222,7 +222,7 @@ func getHiddenElems(req *http.Request) (threads, tags []string) {
 				continue
 			}
 			if s[0] == '#' {
-				tags = append(tags, s)
+				tags = append(tags, s[1:])
 			} else {
 				threads = append(threads, s)
 			}

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -60,25 +60,6 @@ charsCount "reply-form"
 
 window.charsCount = charsCount
 
-# Setup Safe mode button
-safeButton = document.getElementById "safeBtn"
-filter = window.getFilter()
-if "nsfw" in filter
-	safeButton.innerHTML = "EXIT SAFE MODE"
-	safeButton.style.boxShadow = "0 0 0 1px green inset"
-	safeButton.onclick = ->
-		status = window.removeFilter ["nsfw"]
-		location.reload true
-		return
-else
-	safeButton.style.boxShadow = "0 0 0 1px darkred inset"
-	safeButton.onclick = ->
-		status = window.addFilter ["nsfw"]
-		if status == false
-			alert "Cookies are not enabled, Safe mode couldn't be enabled"
-		location.reload true
-		return
-
 # Setup toggle buttons in light mode
 lightimagebtn = document.querySelectorAll ".toggleImage"
 imgsetup = (btn) ->
@@ -99,23 +80,6 @@ toggle?.onclick = ->
 	box = document.getElementById "tagsearch"
 	toggleAutocomplete box, "#{basepath}taglist"
 	box.focus()
-
-# Hiding functions
-toggleHideThread = (url) ->
-	# check if crHidden cookie exists
-	cookie = Cookies.get 'crHidden'
-	unless cookie?
-		Cookies.set 'crHidden', url, { expires: Infinity }
-		return
-	hidden = cookie.split ' '
-	if url in hidden
-		Cookies.set 'crHidden', ((u for u in hidden when u isnt url).join ' '), { expires: Infinity }
-	else
-		Cookies.set 'crHidden', "#{cookie} #{url}", { expires: Infinity }
-
-window.toggleHideThread = toggleHideThread
-
-window.unhideAllThreads = -> Cookies.expire 'crHidden'
 
 # Unhide post actions to admins
 if window.adminMode

--- a/static/src/coffee/hiding.coffee
+++ b/static/src/coffee/hiding.coffee
@@ -1,0 +1,84 @@
+safeButton = document.getElementById "safeBtn"
+unless Cookies.enabled
+	safeButton.onclick = -> alert "Cookies are not enabled, Safe mode not available."
+	return
+
+# Wrapper for the cookie used for hiding.
+# This cookie's value has the form: 'surl1&surl2&#tag1&#tag2&etc'
+class Hidden
+	sep: '&'
+	constructor: (@value) -> @splitted = @value.split @sep
+	tags: -> return (x for x in @splitted when x[0] is '#')
+	threads: -> return (x for x in @splitted when x[0] isnt '#')
+	remove: (what...) ->
+		for w in what
+			@splitted.splice @splitted.indexOf(w), 1
+			@value = @splitted.join @sep
+		@update()
+	add: (what...) ->
+		for w in what
+			continue if w in @splitted
+			@splitted.push w
+		@value = @splitted.join @sep
+		@update()
+	clear: -> @value = ""; @splitted = []; @update()
+	clearThreads: ->
+		@splitted = @tags()
+		@value = @splitted.join @sep
+		@update()
+	clearTags: ->
+		@splitted = @threads()
+		@value = @splitted.join @sep
+		@update()
+	get: (what) ->
+		i = @splitted.indexOf what
+		return null if i < 0
+		return @splitted[i]
+	isEmpty: -> return @value.length is 0
+	update: ->
+		if @isEmpty()
+			Cookies.expire 'crHidden'
+		else
+			Cookies.set 'crHidden', @value, { expires: Infinity }
+
+window.newCrHidden = ->
+	cookie = Cookies.set 'crHidden', ""
+	return new Hidden ""
+
+window.killCrHidden = -> Cookies.expire 'crHidden'
+
+crHidden = undefined
+# find out if the cookies is set and, if so, create a Hidden object
+# wrapping its value.
+cookie = Cookies.get 'crHidden'
+if cookie?
+	crHidden = new Hidden cookie
+
+# Setup Safe mode button
+if crHidden?.get '#nfsw'
+	safeButton.innerHTML = "EXIT SAFE MODE"
+	safeButton.style.boxShadow = "0 0 0 1px green inset"
+	safeButton.onclick = ->
+		crHidden.remove '#nfsw'
+		location.reload true
+		return
+else
+	safeButton.style.boxShadow = "0 0 0 1px darkred inset"
+	safeButton.onclick = ->
+		crHidden = newCrHidden() unless crHidden?
+		crHidden.add '#nfsw'
+		location.reload true
+		return
+
+toggleHideThread = (url) ->
+	# check if this url is already hidden: if so,
+	# unhide it, else hide it.
+	if crHidden?.get url
+		crHidden.remove url
+	else
+		crHidden = newCrHidden() unless crHidden?
+		crHidden.add url
+
+window.toggleHideThread = toggleHideThread
+window.unhideAllThreads = -> crHidden.clearThreads()
+window.unhideAllTags = -> crHidden.clearTags()

--- a/static/src/coffee/utils.coffee
+++ b/static/src/coffee/utils.coffee
@@ -4,12 +4,13 @@ window.stripPage = (url) ->
 	idx = url.indexOf "/page/"
 	return if idx < 0 then url else url.substring 0, idx
 
+###
 window.setFilter = (tags) ->
-	tagList = tags.join ":"
 	return false unless Cookies.enabled
+	tagList = tags.join ":"
 	props =
 		domain: '.' + window.domain.split(":")[0]
-		explires: Infinity
+		expires: Infinity
 	console.log props
 	Cookies.set "filter", tagList, props
 	return true
@@ -33,3 +34,4 @@ window.removeFilter = (toremove) ->
 		continue if tag in toremove
 		newtags.push tag
 	window.setFilter newtags
+###

--- a/template/hidden.html
+++ b/template/hidden.html
@@ -32,5 +32,20 @@
 </article>
 {{/Thread}}
 {{/Last}}
+<hr />
+<article class="hidden2">
+    All hidden tags
+    &nbsp;&nbsp;
+    <a href="{{BasePath}}hidden" class="button" onclick="unhideAllTags()">Unhide all</a>
+</article>
+{{#Tags}}
+<article class="tag-item thread">
+    <h3 class="tag-name"><a href="{{BasePath}}tag/{{Name}}" class="nolink">{{{Name}}}</a></h3>
+    <div>Last updated thread: {{#LastThread}}{{#Thread}}<a href="{{BasePath}}thread/{{ShortUrl}}/page/{{Page}}#p{{LastMessage}}" class="thread-title">{{Title}}</a>{{/Thread}}{{/LastThread}} (<span class="date" data-udate="{{LastUpdate}}">{{StrLastUpdate}}</span>)</div>
+    <div class="right">
+        <a class="noborder hide" href="" onclick="toggleHide('#{{Name}}')">Hide</a>
+    </div>
+</article>
+{{/Tags}}
 <div class="pages" data-current="{{CurrentPage}}" data-max="nomax" data-more="{{#More}}yes{{/More}}{{^More}}no{{/More}}"></div>
 {{/Data}}

--- a/template/hidden.html
+++ b/template/hidden.html
@@ -27,7 +27,7 @@
         </a>
     </div>
     <div class="right">
-        <a class="noborder hide" href="" onclick="toggleHideThread('{{ShortUrl}}')">Unhide</a>
+        <a class="noborder hide" href="" onclick="toggleHide('{{ShortUrl}}')">Unhide</a>
     </div>
 </article>
 {{/Thread}}

--- a/template/home.html
+++ b/template/home.html
@@ -39,6 +39,9 @@
 <article class="tag-item">
     <h3 class="tag-name"><a href="{{BasePath}}tag/{{Name}}" class="nolink">{{{Name}}}</a></h3>
     <div>Last updated thread: {{#LastThread}}{{#Thread}}<a href="{{BasePath}}thread/{{ShortUrl}}/page/{{Page}}#p{{LastMessage}}" class="thread-title">{{Title}}</a>{{/Thread}}{{/LastThread}} (<span class="date" data-udate="{{LastUpdate}}">{{StrLastUpdate}}</span>)</div>
+    <div class="right">
+        <a class="noborder hide" href="" onclick="toggleHideTag('{{Name}}')">Hide</a>
+    </div>
 </article>
 {{/Tags}}
 <a href='{{BasePath}}tags' class="article"><article>View all</article></a>

--- a/template/home.html
+++ b/template/home.html
@@ -25,7 +25,7 @@
         </a>
     </div>
     <div class="right">
-        <a class="noborder hide" href="" onclick="toggleHideThread('{{ShortUrl}}')">Hide</a>
+        <a class="noborder hide" href="" onclick="toggleHide('{{ShortUrl}}')">Hide</a>
     </div>
 </article>
 {{/Thread}}
@@ -36,11 +36,11 @@
     Most popular tags, ordered by popularity.
 </article>
 {{#Tags}}
-<article class="tag-item">
+<article class="tag-item thread">
     <h3 class="tag-name"><a href="{{BasePath}}tag/{{Name}}" class="nolink">{{{Name}}}</a></h3>
     <div>Last updated thread: {{#LastThread}}{{#Thread}}<a href="{{BasePath}}thread/{{ShortUrl}}/page/{{Page}}#p{{LastMessage}}" class="thread-title">{{Title}}</a>{{/Thread}}{{/LastThread}} (<span class="date" data-udate="{{LastUpdate}}">{{StrLastUpdate}}</span>)</div>
     <div class="right">
-        <a class="noborder hide" href="" onclick="toggleHideTag('{{Name}}')">Hide</a>
+        <a class="noborder hide" href="" onclick="toggleHide('#{{Name}}')">Hide</a>
     </div>
 </article>
 {{/Tags}}

--- a/template/layout.html
+++ b/template/layout.html
@@ -59,5 +59,6 @@
     <script src="/static/js/anon.js"></script>
     <script src="/static/js/posts.js"></script>
     <script src="/static/js/complete.js"></script>
+    <script src="/static/js/hiding.js"></script>
 </body>
 </html>

--- a/template/newthread.html
+++ b/template/newthread.html
@@ -3,7 +3,7 @@
     <form id="reply-form" class="ac_wrapper" method="POST" action="{{BasePath}}new">
         <input class="full small" type="text" name="nickname" placeholder="Nickname#Tripcode (optional)" autofocus />
         <input class="full" type="text" name="title" placeholder="Thread title" required />
-        <input class="full small ac_input" type="text" name="tags" placeholder="Tags (separated by #)" autocomplete="off"/>
+        <input class="full small ac_input" type="text" name="tags" placeholder="Tags (separated by #; '&' is illegal.)" autocomplete="off"/>
 
         <!-- Editor buttons -->
         <div id="editorRight">


### PR DESCRIPTION
Ricapitolando:  
* `filterFromCookie` è stato piallato e sostituito da `getHiddenElems`, che prende la request e restituisce `(hiddenThreads, hiddenTags []string, err error)`.
* questa funzione viene quindi usata sia dagli handler che dall'API dove necessario.
* `db.GetThreadList` è stata modificata in modo che accetti due filtri: uno per le tag e uno per i thread. Le altre funzioni del DB sono rimaste tali quali.
* `&` è usato come separatore nel valore del cookie, per cui andrà reso illegale come carattere per le tag (lo faccio io nel prossimo commit)
* al momento la Safe Mode consiste nel controllare se '#nsfw' è presente nel valore di crHidden e schiacciare il bottone setta/toglie dallo stesso cookie quella tag.
* next step: aggiungere il tastino "Hide" di fianco alle tag e mettere anche loro nella pagina /hidden (che è quello che farò adesso)