### PR TITLE
Improvements to Maudtext module

### DIFF
--- a/src/api.go
+++ b/src/api.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"./data"
 	"encoding/json"
 	"fmt"
 	"github.com/gorilla/mux"
@@ -46,7 +47,7 @@ func apiNewThread(rw http.ResponseWriter, req *http.Request) {
 		hTrip = randomString(8)
 		tcode = tripcode(hTrip)
 	}
-	user := User{nickname, tcode, len(hTrip) > 0}
+	user := data.User{nickname, tcode, len(hTrip) > 0}
 	content := postContent
 	tags := parseTags(postTags)
 
@@ -138,7 +139,7 @@ func apiReply(rw http.ResponseWriter, req *http.Request) {
 		hTrip = randomString(8)
 		tcode = tripcode(hTrip)
 	}
-	user := User{nickname, tcode, len(hTrip) > 0}
+	user := data.User{nickname, tcode, len(hTrip) > 0}
 	content := postContent
 
 	if postTooLong(content) {
@@ -185,7 +186,7 @@ func apiPreview(rw http.ResponseWriter, req *http.Request) {
 	content := parseContent(postContent, "bbcode")
 
 	// Do a dummy post for mutators
-	var fakepost Post
+	var fakepost data.Post
 	fakepost.Content = content
 	for _, m := range postmutators {
 		applyPostMutator(m, nil, &fakepost, req)

--- a/src/blacklist.go
+++ b/src/blacklist.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"./data"
 	"encoding/json"
 	"io/ioutil"
 	"log"
@@ -20,7 +21,7 @@ type Blacklist struct {
 }
 
 var blacklists map[string]Blacklist
-var captchas []CaptchaData
+var captchas []data.CaptchaData
 
 func initBL() {
 	// Load Blacklist conf

--- a/src/data/data.go
+++ b/src/data/data.go
@@ -1,4 +1,4 @@
-package main
+package data
 
 import (
 	"gopkg.in/mgo.v2/bson"

--- a/src/database.go
+++ b/src/database.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"./data"
 	"errors"
 	"gopkg.in/mgo.v2"
 	"gopkg.in/mgo.v2/bson"
@@ -31,12 +32,12 @@ func (db Database) Close() {
 	db.session.Close()
 }
 
-func (db Database) NewThread(user User, title, content string, tags []string) (string, error) {
+func (db Database) NewThread(user data.User, title, content string, tags []string) (string, error) {
 	tid := bson.NewObjectId()
 	pid := bson.NewObjectId()
 	now := time.Now().UTC().Unix()
 
-	thread := Thread{
+	thread := data.Thread{
 		Id:         tid,
 		ShortUrl:   generateURL(db, "thread"),
 		Title:      title,
@@ -49,7 +50,7 @@ func (db Database) NewThread(user User, title, content string, tags []string) (s
 		LRDate:     now,
 	}
 
-	post := Post{
+	post := data.Post{
 		Id:          pid,
 		ThreadId:    tid,
 		Author:      user,
@@ -76,8 +77,8 @@ func (db Database) NewThread(user User, title, content string, tags []string) (s
 // of all the thread tags.
 // Returns the number of posts in the thread (after this was inserted) and any error
 // which may have happened during the transaction.
-func (db Database) ReplyThread(thread *Thread, user User, content string) (int, error) {
-	post := Post{
+func (db Database) ReplyThread(thread *data.Thread, user data.User, content string) (int, error) {
+	post := data.Post{
 		Id:          bson.NewObjectId(),
 		ThreadId:    thread.Id,
 		Author:      user,
@@ -114,7 +115,7 @@ func (db Database) ReplyThread(thread *Thread, user User, content string) (int, 
 // a tag matching it (i.e. thread.tag ~ /tag/i); else, return all
 // threads with at least 1 tag matching at least 1 of the words in
 // the `tag` string. Separator is "#"
-func (db Database) GetThreadList(tag string, limit, offset int, hThreads, hTags []string) (threads []Thread, err error) {
+func (db Database) GetThreadList(tag string, limit, offset int, hThreads, hTags []string) (threads []data.Thread, err error) {
 	var filterByTag bson.M
 	tag, err = url.QueryUnescape(tag)
 	tag = html.UnescapeString(tag)
@@ -178,15 +179,15 @@ func (db Database) GetThreadList(tag string, limit, offset int, hThreads, hTags 
 }
 
 // GetThread returns the thread identified by the shorturl `surl`.
-func (db Database) GetThread(surl string) (Thread, error) {
-	var thread Thread
+func (db Database) GetThread(surl string) (data.Thread, error) {
+	var thread data.Thread
 	err := db.database.C("threads").Find(bson.M{"shorturl": surl}).One(&thread)
 	return thread, err
 }
 
 // GetThreads is like GetThread but accepts a string of shorturls.
-func (db Database) GetThreads(surl []string, limit, offset int) ([]Thread, error) {
-	var threads []Thread
+func (db Database) GetThreads(surl []string, limit, offset int) ([]data.Thread, error) {
+	var threads []data.Thread
 	query := db.database.C("threads").Find(bson.M{"shorturl": bson.M{"$in": surl}})
 	if offset > 0 {
 		query = query.Skip(offset)
@@ -199,8 +200,8 @@ func (db Database) GetThreads(surl []string, limit, offset int) ([]Thread, error
 }
 
 // GetTags returns the list of specified tags
-func (db Database) GetTags(tagnames []string, limit, offset int) ([]Tag, error) {
-	var tags []Tag
+func (db Database) GetTags(tagnames []string, limit, offset int) ([]data.Tag, error) {
+	var tags []data.Tag
 	query := db.database.C("tags").Find(bson.M{"name": bson.M{"$in": tagnames}})
 	if offset > 0 {
 		query = query.Skip(offset)
@@ -212,21 +213,21 @@ func (db Database) GetTags(tagnames []string, limit, offset int) ([]Tag, error) 
 	return tags, err
 }
 
-func (db Database) GetThreadById(id bson.ObjectId) (Thread, error) {
-	var thread Thread
+func (db Database) GetThreadById(id bson.ObjectId) (data.Thread, error) {
+	var thread data.Thread
 	err := db.database.C("threads").FindId(id).One(&thread)
 	return thread, err
 }
 
-func (db Database) GetPost(id bson.ObjectId) (Post, error) {
-	var post Post
+func (db Database) GetPost(id bson.ObjectId) (data.Post, error) {
+	var post data.Post
 	err := db.database.C("posts").FindId(id).One(&post)
 	return post, err
 }
 
 // GetPosts fetches the posts of a thread. If `limit` is > 0, fetch
 // up to `limit` posts. If `offset` > 0, start from `offset`-th post.
-func (db Database) GetPosts(thread *Thread, limit, offset int) ([]Post, error) {
+func (db Database) GetPosts(thread *data.Thread, limit, offset int) ([]data.Post, error) {
 	query := db.database.C("posts").Find(bson.M{"threadid": thread.Id}).Sort("date")
 	if offset > 0 {
 		query = query.Skip(offset)
@@ -235,17 +236,17 @@ func (db Database) GetPosts(thread *Thread, limit, offset int) ([]Post, error) {
 		query = query.Limit(limit)
 	}
 
-	var posts []Post
+	var posts []data.Post
 	err := query.All(&posts)
 
 	return posts, err
 }
 
-func (db Database) PostCount(thread *Thread) (int, error) {
+func (db Database) PostCount(thread *data.Thread) (int, error) {
 	return db.database.C("posts").Find(bson.M{"threadid": thread.Id}).Count()
 }
 
-type ByThreads []Tag
+type ByThreads []data.Tag
 
 func (b ByThreads) Len() int           { return len(b) }
 func (b ByThreads) Swap(i, j int)      { b[i], b[j] = b[j], b[i] }
@@ -254,8 +255,8 @@ func (b ByThreads) Less(i, j int) bool { return b[i].Posts < b[j].Posts }
 // GetPopularTags returns a slice of Tags (up to `limit`, starting
 // from `offset`-th) ordered by "popularity". Popularity is greater
 // for tags whose threads have been updated more recently.
-func (db Database) GetPopularTags(limit, offset int, filter []string) ([]Tag, error) {
-	var result []Tag
+func (db Database) GetPopularTags(limit, offset int, filter []string) ([]data.Tag, error) {
+	var result []data.Tag
 	var cond bson.M
 	if filter != nil && len(filter) > 0 {
 		condParts := make([]bson.M, 0)
@@ -284,7 +285,7 @@ func (db Database) NextId(name string) (int64, error) {
 		Upsert:    true,
 		ReturnNew: true,
 	}
-	var doc Counter
+	var doc data.Counter
 	_, err := db.database.C("counters").Find(bson.M{"name": name}).Apply(inc, &doc)
 	return doc.Seq, err
 }
@@ -303,7 +304,7 @@ func (db Database) IncTag(name string, lastThread bson.ObjectId) error {
 		Upsert:    true,
 		ReturnNew: true,
 	}
-	var doc Tag
+	var doc data.Tag
 	_, err := db.database.C("tags").Find(bson.M{"name": name}).Apply(inc, &doc)
 	return err
 }
@@ -317,7 +318,7 @@ func (db Database) DecTag(name string) error {
 		},
 		ReturnNew: true,
 	}
-	var doc Tag
+	var doc data.Tag
 	_, err := db.database.C("tags").Find(bson.M{"name": name}).Apply(inc, &doc)
 	// remove tag if not referred by any thread.
 	if doc.Posts < 1 {
@@ -360,7 +361,7 @@ func (db Database) DeletePost(id bson.ObjectId, admin bool) error {
 // a quite expensive operation.
 // Returns an errors as well as a bool indicating if the thread
 // has been purged as well
-func (db Database) PurgePost(post Post) (error, bool) {
+func (db Database) PurgePost(post data.Post) (error, bool) {
 	// Get thread
 	thread, err := db.GetThreadById(post.ThreadId)
 	if err != nil {
@@ -410,7 +411,7 @@ func (db Database) PurgePost(post Post) (error, bool) {
 
 // PurgeThread deletes an entire thread from the database (IRREVERSIBLE)
 // This also deletes all the posts inside it.
-func (db Database) PurgeThread(thread *Thread) error {
+func (db Database) PurgeThread(thread *data.Thread) error {
 	// Firstly, remove thread from database
 	err := db.database.C("threads").RemoveId(thread.Id)
 	if err != nil {
@@ -444,7 +445,7 @@ func (db Database) SetThreadTags(id bson.ObjectId, newTags []string) error {
 
 // GetMatchingTags returns a slice of Tags matching the given word.
 // If word given is "", the behaviour is the same as DBGetPopularTags.
-func (db Database) GetMatchingTags(word string, limit, offset int, filter []string) ([]Tag, error) {
+func (db Database) GetMatchingTags(word string, limit, offset int, filter []string) ([]data.Tag, error) {
 	if len(word) < 1 {
 		return db.GetPopularTags(limit, offset, filter)
 	}
@@ -460,7 +461,7 @@ func (db Database) GetMatchingTags(word string, limit, offset int, filter []stri
 	if limit > 0 {
 		query = query.Limit(limit)
 	}
-	var tags []Tag
+	var tags []data.Tag
 	err := query.All(&tags)
 	return tags, err
 }

--- a/src/main.go
+++ b/src/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"./data"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -13,10 +14,10 @@ import (
 )
 
 var (
-	adminConf AdminConfig
+	adminConf data.AdminConfig
 	db        Database
 	maudRoot  string
-	siteInfo  SiteInfo
+	siteInfo  data.SiteInfo
 )
 
 func setupHandlers(router *mux.Router, isAdmin, isSubdir bool) {

--- a/src/modules.go
+++ b/src/modules.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"./data"
 	// Formatters
 	"./modules"
 	"./modules/formatters/bbcode"
@@ -36,15 +37,16 @@ func InitFormatters() {
 	postmutators = append(postmutators, maudtext.Provide(siteInfo.PostsPerPage))
 }
 
-func applyPostMutator(m modules.PostMutator, thread *Thread, post *Post, req *http.Request) {
+func applyPostMutator(m modules.PostMutator, thread *data.Thread, post *data.Post, req *http.Request) {
 	if m.Condition(req) {
 		m.Mutator(postMutatorArgs(thread, post, req))
 	}
 }
 
-func postMutatorArgs(thread *Thread, post *Post, req *http.Request) modules.PostMutatorData {
+func postMutatorArgs(thread *data.Thread, post *data.Post, req *http.Request) modules.PostMutatorData {
 	return modules.PostMutatorData{
-		Content: &post.Content,
+		Thread:  thread,
+		Post:    post,
 		Request: req,
 	}
 }

--- a/src/modules/formatters/lightify/lightify.go
+++ b/src/modules/formatters/lightify/lightify.go
@@ -30,9 +30,7 @@ func (f *LightifyFormatter) Init() {
 // and returns the other content unaltered
 func (f *LightifyFormatter) Format(content string) string {
 	for _, match := range f.imgRgx.FindAllStringSubmatch(content, -1) {
-		println("img: ", match[0])
 		url := match[1]
-		println("Format: matched ", url)
 		spl := strings.Split(url, "/")
 		switch {
 		case len(spl) > 2 && spl[2] == "i.imgur.com":

--- a/src/modules/formatters/lightify/lightify.go
+++ b/src/modules/formatters/lightify/lightify.go
@@ -30,7 +30,9 @@ func (f *LightifyFormatter) Init() {
 // and returns the other content unaltered
 func (f *LightifyFormatter) Format(content string) string {
 	for _, match := range f.imgRgx.FindAllStringSubmatch(content, -1) {
+		println("img: ", match[0])
 		url := match[1]
+		println("Format: matched ", url)
 		spl := strings.Split(url, "/")
 		switch {
 		case len(spl) > 2 && spl[2] == "i.imgur.com":
@@ -45,7 +47,7 @@ func (f *LightifyFormatter) Format(content string) string {
 // ReplaceTags replaces all <img> and <iframe> tags (except for thumbnails)
 // with clickable links to get those resources.
 func (f *LightifyFormatter) ReplaceTags(data modules.PostMutatorData) {
-	content := *data.Content
+	content := (*data.Post).Content
 	for _, match := range f.imgRgx.FindAllStringSubmatch(content, -1) {
 		url := match[1]
 		spl := strings.Split(url, "/")
@@ -59,7 +61,7 @@ func (f *LightifyFormatter) ReplaceTags(data modules.PostMutatorData) {
 		}
 	}
 	content = f.iframeRgx.ReplaceAllString(content, "<a target=\"_blank\" href=$1>[Click to open embedded content]</a>")
-	*data.Content = f.videoRgx.ReplaceAllString(content, "<a target=\"_blank\" href=$1>[Click to open embedded video]</a>")
+	(*data.Post).Content = f.videoRgx.ReplaceAllString(content, "<a target=\"_blank\" href=$1>[Click to open embedded video]</a>")
 }
 
 //// Unexported ////

--- a/src/modules/interface.go
+++ b/src/modules/interface.go
@@ -1,6 +1,7 @@
 package modules
 
 import (
+	"../data"
 	"net/http"
 )
 
@@ -10,7 +11,8 @@ type Formatter interface {
 
 type PostMutatorData struct {
 	Request *http.Request
-	Content *string
+	Thread  *data.Thread
+	Post    *data.Post
 }
 
 type PostMutator struct {

--- a/src/modules/maudtext/maudtext.go
+++ b/src/modules/maudtext/maudtext.go
@@ -24,7 +24,7 @@ type MaudtextMutator struct {
 //   >> #postId
 //   > quote
 func (mt *MaudtextMutator) maudtext(data modules.PostMutatorData) {
-	lines := strings.Split(*data.Content, "\n")
+	lines := strings.Split((*data.Post).Content, "\n")
 	vars := mux.Vars(data.Request)
 	threadUrl, threadok := vars["thread"]
 
@@ -39,14 +39,15 @@ func (mt *MaudtextMutator) maudtext(data modules.PostMutatorData) {
 		if threadok && len(stripped) > 9 && stripped[0:9] == "&gt;&gt;#" {
 			if num, err := strconv.ParseInt(stripped[9:], 10, 32); err == nil {
 				// valid post quote
-				lines[idx] = "<a href=\"" + mt.getLink(int(num), threadUrl) + "\" class=\"postIdQuote\">&gt;&gt; #" + strconv.Itoa(int(num)) + "</a><br/>"
+				lines[idx] = "<a href=\"" + mt.getLink(int(num), threadUrl) +
+					"\" class=\"postIdQuote\">&gt;&gt; #" + strconv.Itoa(int(num)) + "</a><br/>"
 				continue
 			}
 		}
 		lines[idx] = "<span class=\"purpletext\">&gt; " + line[4:] + "</span>"
 	}
 
-	*data.Content = strings.Join(lines, "\n")
+	(*data.Post).Content = strings.Join(lines, "\n")
 }
 
 func (mt *MaudtextMutator) getLink(postNum int, threadUrl string) string {

--- a/src/utils.go
+++ b/src/utils.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"./data"
 	"bytes"
 	"crypto/rand"
 	"crypto/sha256"
@@ -147,13 +148,13 @@ func shortify(content string) (string, bool) {
 	return PostPolicy().Sanitize(short), true
 }
 
-func threadPostOrErr(rw http.ResponseWriter, threadId, postIdStr string) (Thread, Post, error) {
+func threadPostOrErr(rw http.ResponseWriter, threadId, postIdStr string) (data.Thread, data.Post, error) {
 	thread, err := db.GetThread(threadId)
 	// retreive post
 	postId, err := strconv.Atoi(postIdStr)
 	if err != nil {
 		sendError(rw, 400, err.Error())
-		return thread, Post{}, err
+		return thread, data.Post{}, err
 	}
 	posts, err := db.GetPosts(&thread, 1, postId)
 	if err != nil {
@@ -241,13 +242,13 @@ func getHiddenElems(req *http.Request) (threads, tags []string) {
 	}
 }
 
-func retreiveThreads(n, offset int, hThreads, hTags []string) ([]ThreadInfo, error) {
+func retreiveThreads(n, offset int, hThreads, hTags []string) ([]data.ThreadInfo, error) {
 	threads, err := db.GetThreadList("", n, offset, hThreads, hTags)
 	if err != nil {
 		return nil, err
 	}
 
-	tinfos := make([]ThreadInfo, 0, siteInfo.HomeThreadsNum)
+	tinfos := make([]data.ThreadInfo, 0, siteInfo.HomeThreadsNum)
 	for i, _ := range threads {
 
 		count, err := db.PostCount(&threads[i])
@@ -260,10 +261,10 @@ func retreiveThreads(n, offset int, hThreads, hTags []string) ([]ThreadInfo, err
 			return tinfos, err
 		}
 
-		tinfos = append(tinfos, ThreadInfo{
+		tinfos = append(tinfos, data.ThreadInfo{
 			Thread:      threads[i],
 			LastMessage: count - 1,
-			LastPost: PostInfo{
+			LastPost: data.PostInfo{
 				Data:    lastPost,
 				StrDate: strdate(lastPost.Date),
 			},
@@ -276,9 +277,9 @@ func retreiveThreads(n, offset int, hThreads, hTags []string) ([]ThreadInfo, err
 	return tinfos, err
 }
 
-func randomCaptcha() (CaptchaData, error) {
+func randomCaptcha() (data.CaptchaData, error) {
 	if len(captchas) < 1 {
-		return CaptchaData{}, errors.New("Sorry, captchas weren't configured properly.")
+		return data.CaptchaData{}, errors.New("Sorry, captchas weren't configured properly.")
 	}
 	return captchas[mathrand.Intn(len(captchas))], nil
 }

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -121,6 +121,25 @@ if window.adminMode
 fromList(document.querySelectorAll('.postIdQuote')).map (e) ->
 	e.onmouseover = ->
 		refId = "p#{e.innerHTML[10..]}"
-		document.getElementById(refId)?.classList?.add 'highlighted'
+		ref = document.getElementById refId
+		if ref?.classList?
+			if ref.getBoundingClientRect().y > 0
+				ref.classList.add 'highlighted'
+			else
+				quoted = e.parentNode.querySelector '.post.quoted'
+				unless quoted?
+					quoted = document.createElement 'article'
+					quoted.innerHTML = ref.innerHTML
+					quoted.className =  'post quoted'
+					quoted.style.top = "-#{ref.clientHeight-30}px"
+					e.parentNode.insertBefore quoted, e
+				quoted.style.display = 'block'
+
+			
 	e.onmouseout = ->
-		document.querySelector('.post.highlighted')?.classList?.remove 'highlighted'
+		post = document.querySelector '.post.highlighted'
+		if post?
+			post.classList.remove 'highlighted'
+		else
+			quoted = e.parentNode.querySelector '.post.quoted'
+			quoted?.style.display = ''

--- a/static/src/scss/screen.scss
+++ b/static/src/scss/screen.scss
@@ -172,6 +172,14 @@ a.nolink { border: 0; }
 	&.highlighted {
 		background-color: rgba(100,100,100,.4);
 	}
+	&.quoted {
+		display: none;
+		position: absolute;
+		background-color: rgba(0,0,0,0.9);
+		left: 60px;
+		padding: 10px; margin: 2px 0;
+		z-index: 5;
+	}
 }
 
 .right {

--- a/stiki/formatting.html
+++ b/stiki/formatting.html
@@ -19,8 +19,8 @@
 		<td><u>underlined text</u></td>
 	</tr>
 	<tr>
-		<td><code>[strike]<gray>striked</gray>[/strike]</code></td>
-		<td><strike>striked</strike></td>
+		<td><code>[s]<gray>striked</gray>[/s]</code></td>
+		<td><s>striked</s></td>
 	</tr>
 	<tr>
 		<td><code>[img]<gray>http://imgu..</gray>[/img]</code></td>


### PR DESCRIPTION
Come accennato in #74, rendiamo il post quote by id più powa facendo apparire il testo citato on hover.

**EDIT**: adesso facciamo tutto client-side, senza cambiamenti lato server.

(vecchio testo:)
**Cose che questo ha richiesto finora**:  
* modulizzare `data` e `database`
* aggiungere all'interfaccia dei moduli una struct `ThreadMutator`, che è come `PostMutator` ma ha bisogno di tutti i post della pagina correntemente servita
* di conseguenza, `maudtext` è ora un `ThreadMutator`

**Cose che mancano**:  
* Aggiungere l'autore al post quotato (finora quota solo il testo)
* Parsare il testo del post quotato qualora non sia già stato fatto (ovvero quando il post è di un'altra pagina) -> modulizzare `utils` ha senso?
* Migliorare l'HTML/CSS del post quotato?

**Note**:  
* Adesso `maudtext` potenzialmente fa delle query al db; questo accade però di rado, visto che lo fa solo quando il post quotato non si trova nella pagina corrente e lo fa solo la prima volta per ogni post, dopodiché usa una mini-cache interna per i successivi quote dello stesso post.