### PR TITLE
No-JS fallbacks

### DIFF
--- a/errors/403.html
+++ b/errors/403.html
@@ -19,11 +19,9 @@
 }
 #maud img {
     position: absolute;
-    top: 0px;
-    left: 0px;
 }
 #corneas { z-index: 0; width: 100%; }
-#eye     { z-index: 1; width: 10%; }
+#eye     { z-index: 1; width: 10%; left: 264px; top: 210px; }
 #base    { z-index: 3; width: 100%; }
 </style>
 <script>

--- a/src/handlers.go
+++ b/src/handlers.go
@@ -570,7 +570,6 @@ func httpEditPost(rw http.ResponseWriter, req *http.Request) {
 	// Retreive post content
 	thread, post, err := threadPostOrErr(rw, vars["thread"], vars["post"])
 	if err != nil {
-		sendError(rw, 500, err.Error())
 		return
 	}
 
@@ -586,8 +585,6 @@ func httpEditPost(rw http.ResponseWriter, req *http.Request) {
 	if isOp {
 		tags = "#" + strings.Join(thread.Tags, " #")
 	}
-
-	println("post content: ", post.Content)
 
 	send(rw, req, "edit", "Edit post", struct {
 		Thread   string
@@ -613,9 +610,8 @@ func httpDeletePost(rw http.ResponseWriter, req *http.Request) {
 	isAdmin, _ := isAdmin(req)
 
 	// Retreive post content
-	thread, post, err := threadPostOrErr(rw, vars["thread"], vars["post"])
+	_, post, err := threadPostOrErr(rw, vars["thread"], vars["post"])
 	if err != nil {
-		sendError(rw, 500, err.Error())
 		return
 	}
 
@@ -626,24 +622,16 @@ func httpDeletePost(rw http.ResponseWriter, req *http.Request) {
 		}
 	}
 
-	isOp := post.Id == thread.ThreadPost
-	var tags string
-	if isOp {
-		tags = "#" + strings.Join(thread.Tags, " #")
-	}
-
-	send(rw, req, "edit", "Edit post", struct {
+	send(rw, req, "delete", "Delete post", struct {
 		Thread   string
 		Post     string
 		Nickname string
-		IsOP     bool
-		Tags     string
+		IsAdmin  bool
 	}{
 		vars["thread"],
 		vars["post"],
 		post.Author.Nickname,
-		isOp,
-		tags,
+		isAdmin,
 	})
 }
 

--- a/src/main.go
+++ b/src/main.go
@@ -29,6 +29,8 @@ func setupHandlers(router *mux.Router, isAdmin, isSubdir bool) {
 	SetHandler(GET, "/tag/{tag}/page/{page}", httpTagSearch, isAdmin, isSubdir)
 	SetHandler(GET, "/thread/{thread}", httpThread, isAdmin, isSubdir)
 	SetHandler(GET, "/thread/{thread}/page/{page}", httpThread, isAdmin, isSubdir)
+	SetHandler(GET, "/thread/{thread}/post/{post}/edit", httpEditPost, isAdmin, isSubdir)
+	SetHandler(GET, "/thread/{thread}/post/{post}/delete", httpDeletePost, isAdmin, isSubdir)
 	SetHandler(GET, "/new", httpNewThread, isAdmin, isSubdir)
 	SetHandler(GET, "/threads", httpAllThreads, isAdmin, isSubdir)
 	SetHandler(GET, "/threads/page/{page}", httpAllThreads, isAdmin, isSubdir)

--- a/src/modules/formatters/lightify/lightify.go
+++ b/src/modules/formatters/lightify/lightify.go
@@ -55,11 +55,11 @@ func (f *LightifyFormatter) ReplaceTags(data modules.PostMutatorData) {
 		case len(spl) > 2 && f.derpiRgx.MatchString(spl[2]):
 			continue
 		default:
-			content = strings.Replace(content, match[0], "<a class='toggleImage' data-url="+url+">[Click to view image]</a>", 1)
+			content = strings.Replace(content, match[0], "<a class='toggleImage' target='_blank' href="+url+">[Click to view image]</a>", 1)
 		}
 	}
-	content = f.iframeRgx.ReplaceAllString(content, "<a target=\"_blank\" href=$1>[Click to open embedded content]</a>")
-	(*data.Post).Content = f.videoRgx.ReplaceAllString(content, "<a target=\"_blank\" href=$1>[Click to open embedded video]</a>")
+	content = f.iframeRgx.ReplaceAllString(content, "<a target='_blank' href=$1>[Click to open embedded content]</a>")
+	(*data.Post).Content = f.videoRgx.ReplaceAllString(content, "<a target='_blank' href=$1>[Click to open embedded video]</a>")
 }
 
 //// Unexported ////

--- a/src/utils.go
+++ b/src/utils.go
@@ -179,7 +179,7 @@ func threadPostOrErr(rw http.ResponseWriter, threadId, postIdStr string) (data.T
 	}
 	if len(posts) < 1 {
 		sendError(rw, 404, "Post not found")
-		return thread, posts[0], errors.New("Post not found")
+		return thread, data.Post{}, errors.New("Post not found")
 	}
 	return thread, posts[0], nil
 }

--- a/static/src/coffee/editor.coffee
+++ b/static/src/coffee/editor.coffee
@@ -21,6 +21,21 @@ quoteText = (elem) ->
 	txt.selectionStart = txt.selectionEnd = txt.value.length + 1
 	txt.focus()
 
+# Setup editor buttons
+document.getElementById('editorButtons')?.innerHTML = """
+    <a onclick="Editor.add(this, 'b')"><b>B</b></a>
+    <a onclick="Editor.add(this, 'i')"><i>i</i></a>
+    <a onclick="Editor.add(this, 'u')"><u>u</u></a>
+    <a onclick="Editor.add(this, 's')"><s>strike</s></a>
+    <a onclick="Editor.add(this, 'img')">img</a>
+    <a onclick="Editor.add(this, 'url')"><span style="border-bottom: 1px dotted #fff">url</span></a>
+    <a onclick="Editor.add(this, 'spoiler')">spoiler</a>
+    <a onclick="Editor.add(this, 'youtube')">youtube</a>
+    <a onclick="Editor.add(this, 'html')">html</a>
+    <a onclick="Editor.add(this, 'video')">video</a>
+    <a onclick="Editor.quoteText(this)">&gt;</a>
+"""
+
 window.Editor =
 	add: editorAdd
 	quoteText: quoteText

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -95,9 +95,11 @@ window.charsCount = charsCount
 # Setup toggle buttons in light mode
 lightimagebtn = document.querySelectorAll ".toggleImage"
 imgsetup = (btn) ->
-	btn.onclick = ->
-		url = btn.dataset.url
-		btn.outerHTML = "<a href=\"#{url}\"><img src=\"#{url}\" /></a>"
+	url = btn.href
+	do (url) ->
+		btn.removeAttribute 'href'
+		btn.onclick = ->
+			btn.outerHTML = "<a href=\"#{url}\"><img src=\"#{url}\" /></a>"
 imgsetup imgbtn for imgbtn in lightimagebtn
 
 # Tag search / Fulltext search buttons (in pages which have it)
@@ -119,7 +121,7 @@ if toggle?
 if window.adminMode
 	con.style.display = "inline-block" for con in document.querySelectorAll ".postactions"
 
-# Setup onclick event for postIdQuote
+# Setup onhover event for postIdQuote
 fromList(document.querySelectorAll('.postIdQuote')).map (e) ->
 	e.onmouseover = (ev) ->
 		postNum = e.innerHTML[10..]

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -101,17 +101,19 @@ imgsetup = (btn) ->
 imgsetup imgbtn for imgbtn in lightimagebtn
 
 # Tag search / Fulltext search buttons (in pages which have it)
-toggle = document.getElementById "tagsearchbtn"
-toggle?.onclick = ->
-	toggle.outerHTML = """
-    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" method="POST" action="#{basepath}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
-        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
-        <input type="submit" value="Search" />
-    </form>
-	"""
-	box = document.getElementById "tagsearch"
-	AC.toggleAutocomplete box, "#{basepath}taglist"
-	box.focus()
+toggle = document.getElementById "tagsearch-form"
+if toggle?
+	toggle.outerHTML = '<a class="button" id="tagsearchbtn" rel="search">Tag search</a>'
+	toggle = document.getElementById "tagsearchbtn"
+	toggle.onclick = ->
+		toggle.outerHTML = """
+		    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" method="POST" action="#{basepath}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+			<input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+			<input type="submit" value="Search" />
+		    </form>"""
+		box = document.getElementById "tagsearch"
+		AC.toggleAutocomplete box, "#{basepath}taglist"
+		box.focus()
 
 # Unhide post actions to admins
 if window.adminMode

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -110,7 +110,7 @@ if toggle?
 	toggle.onclick = ->
 		toggle.outerHTML = """
 		    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" method="POST" action="#{basepath}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
-			<input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+			<input class="ac_input" data-ac_search="on" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
 			<input type="submit" value="Search" />
 		    </form>"""
 		box = document.getElementById "tagsearch"

--- a/static/src/coffee/posts.coffee
+++ b/static/src/coffee/posts.coffee
@@ -180,17 +180,22 @@ quotePostId = (id) ->
 # remove fallback and set onclick events
 fromList(document.getElementsByClassName 'postEditLink').map (e) ->
 	postId = e.dataset?.postid
-	console.log postId
 	return unless postId?
 	e.href = "#p#{postId}"
 	e.className ="edit nolink"
 	do (postId) ->
 		e.onclick = -> editPost parseInt(postId, 10)
 
+fromList(document.getElementsByClassName 'postDeleteLink').map (e) ->
+	postId = e.dataset?.postid
+	return unless postId?
+	e.href = "#p#{postId}"
+	e.className ="delete nolink"
+	do (postId) ->
+		e.onclick = -> deletePost parseInt(postId, 10)
+
 # expose functions
 window.Posts =
-	editPost: editPost
-	deletePost: deletePost
 	cancelForm: cancelForm
 	showPreview: showPreview
 	replyPreSubmit: replyPreSubmit

--- a/static/src/coffee/posts.coffee
+++ b/static/src/coffee/posts.coffee
@@ -177,6 +177,16 @@ quotePostId = (id) ->
 	window.location.href = '#reply'
 	text.focus()
 
+# remove fallback and set onclick events
+fromList(document.getElementsByClassName 'postEditLink').map (e) ->
+	postId = e.dataset?.postid
+	console.log postId
+	return unless postId?
+	e.href = "#p#{postId}"
+	e.className ="edit nolink"
+	do (postId) ->
+		e.onclick = -> editPost parseInt(postId, 10)
+
 # expose functions
 window.Posts =
 	editPost: editPost

--- a/static/src/coffee/threads.coffee
+++ b/static/src/coffee/threads.coffee
@@ -24,7 +24,7 @@ if window.location.pathname[1...8] == 'thread/'
 	# actually seen. Also save number of replies, and make the thread link
 	# point to the latest read post instead of last one.
 	pages = document.querySelector 'div.pages'
-	return unless pages.dataset.current == pages.dataset.max
+	return unless pages?.dataset? and (pages.dataset.current == pages.dataset.max)
 	# grab latest post
 	posts = document.getElementById('replies').querySelectorAll 'article.post'
 	nreplies = posts.length

--- a/template/delete.html
+++ b/template/delete.html
@@ -1,0 +1,21 @@
+<section><h2 style="padding: 2px 5px;">Deleting post</h2></section>
+<section class="form">
+{{#Data}}
+    <form method="POST" action="{{BasePath}}thread/{{Thread}}/post/{{Post}}/delete">
+        <div>
+            <span class="full verysmall nickname" style="display: inline-block; border: 0; width: auto">{{Nickname}}</span>
+            {{^IsAdmin}}
+			<input class="full short inline verysmall" type="text" name="tripcode" placeholder="Tripcode (required)" required />
+            {{/IsAdmin}}
+            <span style="color: #ccc; display: inline-block; width: auto; font-size: 0.9em;">deleting {{Thread}}/#p{{Post}}</span>
+        </div>
+        <div class="center">
+            <button name="deletetype" value="soft" type="submit">Delete</button>
+            {{#IsAdmin}}
+            <button name="deletetype" value="purge" type="submit">Purge</button>
+            {{/IsAdmin}}
+            <a class="button" href="{{BasePath}}thread/{{Thread}}">Back</a>
+        </div>
+  </form>
+{{/Data}}
+</section>

--- a/template/edit.html
+++ b/template/edit.html
@@ -21,7 +21,7 @@
         <div class="center">
             <div class="chars-count" data-maxlen="#{maxlen}"></div>
             <input type="Submit" value="Edit post"/>
-            <a class="button" href="{{BasePath}}/thread/{{Thread}}">Back</a>
+            <a class="button" href="{{BasePath}}thread/{{Thread}}">Back</a>
         </div>
     </form>
 {{/Data}}

--- a/template/edit.html
+++ b/template/edit.html
@@ -1,0 +1,36 @@
+<section><h2 style="padding: 2px 5px;">Editing post</h2></section>
+<section class="form">
+{{#Data}}
+    <form id="edit-form" class="ac_wrapper" method="POST" action="{{BasePath}}thread/{{Thread}}/post/{{Post}}/edit">
+        <div>
+            <span class="full verysmall nickname" style="display: inline-block; border: 0; width: auto">{{Nickname}}</span>
+            {{^IsAdmin}}
+			<input class="full short inline verysmall" type="text" name="tripcode" placeholder="Tripcode (required)" required />
+            {{/IsAdmin}}
+            <span style="color: #ccc; display: inline-block; width: auto; font-size: 0.9em;">editing {{Thread}}/#p{{Post}}</span>
+        </div>
+        <!-- Editor buttons -->
+        <div id="editorRight" class="small">
+            <a target="_blank" href="/stiki/formatting" rel="help">?</a>
+        </div>
+        <div id="editorButtons" class="small"></div>
+        <textarea class="full small editor" name="text" required>{{{Content}}}</textarea>
+        {{#IsOP}}
+        <input class="full small ac_input" type="text" name="tags" placeholder="Tags (separated by #)" value="{{{Tags}}}" autocomplete="off"/>
+        {{/IsOP}}
+        <div class="center">
+            <div class="chars-count" data-maxlen="#{maxlen}"></div>
+            <input type="Submit" value="Edit post"/>
+            <a class="button" href="{{BasePath}}/thread/{{Thread}}">Back</a>
+        </div>
+    </form>
+{{/Data}}
+</section>
+<script src="/static/js/editor.js"></script>
+<script>
+window.onload = function () {
+    if (AC) {
+        AC.toggleAutocomplete(document.querySelector('#edit-form .ac_input'), '/taglist');
+    }
+}
+</script>

--- a/template/hidden.html
+++ b/template/hidden.html
@@ -1,6 +1,9 @@
 <nav>
     <a href="{{BasePath}}new" class="button">New thread</a>
-    <a class="button" id="tagsearchbtn" rel="search">Tag search</a>
+    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" rel="search" method="POST" action="{{BasePath}}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+        <input type="submit" value="Search" />
+    </form>
     <a href="{{BasePath}}stiki" class="button" rel="prefetch">Stiki</a>
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>

--- a/template/home.html
+++ b/template/home.html
@@ -1,6 +1,9 @@
 <nav>
     <a href="{{BasePath}}new" class="button">New thread</a>
-    <a class="button" id="tagsearchbtn" rel="search">Tag search</a>
+    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" rel="search" method="POST" action="{{BasePath}}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+        <input type="submit" value="Search" />
+    </form>
     <a href="{{BasePath}}stiki" class="button" rel="prefetch">Stiki</a>
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>

--- a/template/newthread.html
+++ b/template/newthread.html
@@ -9,19 +9,7 @@
         <div id="editorRight">
             <a target="_blank" href="/stiki/formatting" rel="help">?</a>
         </div>
-        <div id="editorButtons">
-            <a onclick="Editor.add(this, 'b')"><b>B</b></a>
-            <a onclick="Editor.add(this, 'i')"><i>i</i></a>
-            <a onclick="Editor.add(this, 'u')"><u>u</u></a>
-            <a onclick="Editor.add(this, 's')"><s>strike</s></a>
-            <a onclick="Editor.add(this, 'img')">img</a>
-            <a onclick="Editor.add(this, 'url')"><span style="border-bottom: 1px dotted #fff">url</span></a>
-            <a onclick="Editor.add(this, 'spoiler')">spoiler</a>
-            <a onclick="Editor.add(this, 'youtube')">youtube</a>
-            <a onclick="Editor.add(this, 'html')">html</a>
-            <a onclick="Editor.add(this, 'video')">video</a>
-            <a onclick="Editor.quoteText(this)">&gt;</a>
-        </div>
+        <div id="editorButtons"></div>
 
         <textarea class="full small" name="text" required placeholder="Thread text (BBCode / Markdown)"></textarea>
         {{#Data}}{{#Captcha}}

--- a/template/stiki-index.html
+++ b/template/stiki-index.html
@@ -1,6 +1,9 @@
 <nav>
     <a href="{{BasePath}}new" class="button">New thread</a>
-    <a class="button" id="tagsearchbtn" rel="search">Tag search</a>
+    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" rel="search" method="POST" action="{{BasePath}}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+        <input type="submit" value="Search" />
+    </form>
     <a href="{{BasePath}}stiki" class="button" rel="prefetch">Stiki</a>
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>

--- a/template/tags.html
+++ b/template/tags.html
@@ -1,6 +1,9 @@
 <nav>
     <a href="/new" class="button">New thread</a>
-    <a class="button" id="tagsearchbtn">Tag search</a>
+    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" rel="search" method="POST" action="{{BasePath}}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+        <input type="submit" value="Search" />
+    </form>
     <a href="{{BasePath}}stiki" class="button">Stiki</a>
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>

--- a/template/tagsearch.html
+++ b/template/tagsearch.html
@@ -1,6 +1,9 @@
 <nav>
     <a href="{{BasePath}}new" class="button">New thread</a>
-    <a class="button" id="tagsearchbtn">Tag search</a>
+    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" rel="search" method="POST" action="{{BasePath}}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+        <input type="submit" value="Search" />
+    </form>
     <a href="{{BasePath}}stiki" class="button">Stiki</a>
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>

--- a/template/thread.html
+++ b/template/thread.html
@@ -33,7 +33,7 @@
             <a class="postEditLink edit noborder" data-postid="0" href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/post/{{PostId}}/edit">
                 <img src="/static/images/edit.svg" style="height: 20px;" />
             </a>
-            <a href="#thread" class="delete nolink" onclick="Posts.deletePost(0)">
+            <a class="postDeleteLink delete noborder" data-postid="0" href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/post/{{PostId}}/delete">
                 <img src="/static/images/delete.svg" style="height: 18px;" />
             </a>
         </div>
@@ -60,7 +60,7 @@
             <a class="postEditLink edit noborder" data-postid="{{PostId}}" href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/post/{{PostId}}/edit">
                 <img src="/static/images/edit.svg" style="height: 20px;" />
             </a>
-            <a href="#p{{PostId}}" class="delete nolink" onclick="Posts.deletePost({{PostId}})">
+            <a class="postDeleteLink delete noborder" data-postid="{{PostId}}" href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/post/{{PostId}}/delete">
                 <img src="/static/images/delete.svg" style="height: 18px;" />
             </a>
         </div>

--- a/template/thread.html
+++ b/template/thread.html
@@ -30,7 +30,7 @@
     <div class="right">
         {{#Modified}}<span class="lastedit" data-udate="{{LastModified}}">edited {{StrLastModified}}</span>{{/Modified}}
         <div id="p0_btn" class="postactions" {{^Editable}}style='display: none'{{/Editable}} />
-            <a href="#thread" class="edit nolink" onclick="Posts.editPost(0)">
+            <a class="postEditLink edit noborder" data-postid="0" href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/post/{{PostId}}/edit">
                 <img src="/static/images/edit.svg" style="height: 20px;" />
             </a>
             <a href="#thread" class="delete nolink" onclick="Posts.deletePost(0)">
@@ -57,7 +57,7 @@
     <div class="right">
         {{#Modified}}<span class="lastedit" data-udate="{{LastModified}}">edited {{StrLastModified}}</span>{{/Modified}}
         <div id="p{{PostId}}_btn" class="postactions" {{^Editable}}style='display: none'{{/Editable}} />
-            <a href="#p{{PostId}}" class="edit nolink" onclick="Posts.editPost({{PostId}})">
+            <a class="postEditLink edit noborder" data-postid="{{PostId}}" href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/post/{{PostId}}/edit">
                 <img src="/static/images/edit.svg" style="height: 20px;" />
             </a>
             <a href="#p{{PostId}}" class="delete nolink" onclick="Posts.deletePost({{PostId}})">

--- a/template/thread.html
+++ b/template/thread.html
@@ -1,6 +1,9 @@
 <nav>
     <a href="#reply" class="button">Reply</a>
-    <a class="button" id="tagsearchbtn" rel="search">Tag search</a>
+    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" rel="search" method="POST" action="{{BasePath}}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+        <input type="submit" value="Search" />
+    </form>
     <a href="{{BasePath}}stiki" class="button" rel="prefetch">Stiki</a>
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>

--- a/template/thread.html
+++ b/template/thread.html
@@ -82,19 +82,7 @@
         <div id="editorRight" class="small">
             <a target="_blank" href="/stiki/formatting" rel="help">?</a>
         </div>
-        <div id="editorButtons" class="small">
-            <a onclick="Editor.add(this, 'b')"><b>B</b></a>
-            <a onclick="Editor.add(this, 'i')"><i>i</i></a>
-            <a onclick="Editor.add(this, 'u')"><u>u</u></a>
-            <a onclick="Editor.add(this, 's')"><s>strike</s></a>
-            <a onclick="Editor.add(this, 'img')">img</a>
-            <a onclick="Editor.add(this, 'url')"><span style="border-bottom: 1px dotted #fff">url</span></a>
-            <a onclick="Editor.add(this, 'spoiler')">spoiler</a>
-            <a onclick="Editor.add(this, 'youtube')">youtube</a>
-            <a onclick="Editor.add(this, 'html')">html</a>
-            <a onclick="Editor.add(this, 'video')">video</a>
-            <a onclick="Editor.quoteText(this)">&gt;</a>
-        </div>
+        <div id="editorButtons" class="small"></div>
         <textarea class="full verysmall" name="text" required placeholder="Post content (Markdown, HTML and BBCode are supported)"></textarea>
         {{#NeedsCaptcha}}{{#Captcha}}
         <span style="display: inline-block; margin: 5px">{{Question}}&nbsp;</span>

--- a/template/threads.html
+++ b/template/threads.html
@@ -1,6 +1,9 @@
 <nav>
     <a href="{{BasePath}}new" class="button">New thread</a>
-    <a class="button" id="tagsearchbtn">Tag search</a>
+    <form id="tagsearch-form" class="ac_wrapper" style="display: inline-block" rel="search" method="POST" action="{{BasePath}}tagsearch" onsubmit="this.querySelector('#tagsearch').value = escapeHTML(this.querySelector('#tagsearch').value); return true">
+        <input class="ac_input" type="text" name="tags" id="tagsearch" placeholder="Filter by tag" required title="Insert tags (each starting with '#')" autocomplete="off" />
+        <input type="submit" value="Search" />
+    </form>
     <a href="{{BasePath}}stiki" class="button">Stiki</a>
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>


### PR DESCRIPTION
Aggiunti fallback per:

* __tagsearch__: in caso di assenza di Javascript, appare il form direttamente invece del button
* __editor__: in assenza di JS, non appaiono i bottoni dell'editor
* __toggleImage__: in assenza di JS, redirige su target=_blank
* __postEdit__ e __postDelete__: in assenza di JS, dirigono su pagine gestite dagli handler `httpEditPost` e `httpDeletePost`
* __error 403__: l'occhio di Maud era posizionato male in mancanza di JS