### PR TITLE
no-JS fallback for pages and hiding

### DIFF
--- a/src/data/data.go
+++ b/src/data/data.go
@@ -23,6 +23,15 @@ type Counter struct {
 	Seq  int64
 }
 
+type PageInfo struct {
+	Page     int
+	HasPrev  bool
+	PrevPage int
+	HasNext  bool
+	NextPage int
+	MaxPage  int
+}
+
 type Post struct {
 	Id           bson.ObjectId "_id"
 	ThreadId     bson.ObjectId

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -24,20 +24,11 @@ fromList(document.querySelectorAll ".type blockquote p").map (e) ->
 makePageLists = ->
 	pageDivs = document.querySelectorAll ".pages"
 	for pageDiv in pageDivs
-		page = parseInt pageDiv.dataset.current
-		baseurl = stripPage location.pathname
-		maxstr = pageDiv.dataset.max
-		more = pageDiv.dataset.more
 		# Do Next/Previous only when we don't know the number of pages
-		if maxstr == "nomax"
-			pageHTML = ""
-			if page > 1
-				pageHTML += "<a href=\"#{baseurl}/page/#{page - 1}\" rel=\"prev\">&laquo; Back</a> "
-			pageHTML += "<b>#{page}</b>"
-			if more == "yes"
-				pageHTML += " <a href=\"#{baseurl}/page/#{page + 1}\" rel=\"next\">Next &raquo;</a>"
-			pageDiv.innerHTML = pageHTML
-		else
+		maxstr = pageDiv.dataset.max
+		if maxstr isnt 'nomax'
+			page = parseInt pageDiv.dataset.current
+			baseurl = stripPage location.pathname
 			max = parseInt maxstr
 			if max > 1
 				pageHTML = "PAGE &nbsp;"

--- a/static/src/coffee/hiding.coffee
+++ b/static/src/coffee/hiding.coffee
@@ -84,6 +84,10 @@ toggleHide = (elem) ->
 		location.reload true
 		return
 
+# Bind click events on threads and tags
+fromList(document.querySelectorAll 'div.hiding').map (e) ->
+        e.innerHTML = """<a class="noborder hide" href="" onclick="Hiding.toggleHide('#{e.dataset.arg}')">Hide</a>"""
+
 window.Hiding =
 	toggleHide: toggleHide
 	unhideAllThreads: -> crHidden.clearThreads()

--- a/template/hidden.html
+++ b/template/hidden.html
@@ -50,5 +50,15 @@
     </div>
 </article>
 {{/Tags}}
-<div class="pages" data-current="{{CurrentPage}}" data-max="nomax" data-more="{{#More}}yes{{/More}}{{^More}}no{{/More}}"></div>
+<div class="pages" data-max="nomax">
+{{#Pages}}
+    {{#HasPrev}}
+    <a href="{{BasePath}}hidden/page/{{PrevPage}}" rel="prev">&laquo; Back</a>
+    {{/HasPrev}}
+    <b>{{Page}}</b>
+    {{#HasNext}}
+    <a href="{{BasePath}}hidden/page/{{NextPage}}" rel="next">Next &raquo;</a>
+    {{/HasNext}}
+{{/Pages}}
+</div>
 {{/Data}}

--- a/template/home.html
+++ b/template/home.html
@@ -28,9 +28,7 @@
             {{/Data}}{{/LastPost}}
         </a>
     </div>
-    <div class="right">
-        <a class="noborder hide" href="" onclick="Hiding.toggleHide('{{ShortUrl}}')">Hide</a>
-    </div>
+    <div class="right hiding" data-arg="{{ShortUrl}}"></div>
 </article>
 {{/Thread}}
 {{/Last}}
@@ -43,9 +41,7 @@
 <article class="tag-item thread">
     <h3 class="tag-name"><a href="{{BasePath}}tag/{{Name}}" class="nolink">{{{Name}}}</a></h3>
     <div>Last updated thread: {{#LastThread}}{{#Thread}}<a href="{{BasePath}}thread/{{ShortUrl}}/page/{{Page}}#p{{LastMessage}}" class="thread-title">{{Title}}</a>{{/Thread}}{{/LastThread}} (<span class="date" data-udate="{{LastUpdate}}">{{StrLastUpdate}}</span>)</div>
-    <div class="right">
-        <a class="noborder hide" href="" onclick="Hiding.toggleHide('#{{Name}}')">Hide</a>
-    </div>
+    <div class="right hiding" data-arg="#{{Name}}"></div>
 </article>
 {{/Tags}}
 <a href='{{BasePath}}tags' class="article"><article>View all</article></a>

--- a/template/tags.html
+++ b/template/tags.html
@@ -16,10 +16,18 @@
 <article class="tag-item thread">
     <h3 class="tag-name"><a href="{{BasePath}}tag/{{Name}}" class="nolink">{{{Name}}}</a></h3>
     <div>Last updated thread: {{#LastThread}}{{#Thread}}<a href="{{BasePath}}thread/{{ShortUrl}}/page/{{Page}}#p{{LastMessage}}" class="thread-title">{{Title}}</a>{{/Thread}}{{/LastThread}} (<span class="date" data-udate="{{LastUpdate}}">{{StrLastUpdate}}</span>)</div>
-    <div class="right">
-        <a class="noborder hide" href="" onclick="Hiding.toggleHide('#{{Name}}')">Hide</a>
-    </div>
+    <div class="right hiding" data-arg="#{{Name}}"></div>
 </article>
 {{/Tags}}
-<div class="pages" data-current="{{CurrentPage}}" data-max="nomax" data-more="{{#More}}yes{{/More}}{{^More}}no{{/More}}"></div>
+<div class="pages" data-max="nomax">
+{{#Pages}}
+    {{#HasPrev}}
+    <a href="{{BasePath}}tags/page/{{PrevPage}}" rel="prev">&laquo; Back</a>
+    {{/HasPrev}}
+    <b>{{Page}}</b>
+    {{#HasNext}}
+    <a href="{{BasePath}}tags/page/{{NextPage}}" rel="next">Next &raquo;</a>
+    {{/HasNext}}
+{{/Pages}}
+</div>
 {{/Data}}

--- a/template/tagsearch.html
+++ b/template/tagsearch.html
@@ -8,7 +8,17 @@
     <a href="{{BasePath}}hidden" class="button">Hidden</a>
 </nav>
 {{#Data}}
-<div class="pages" data-current="{{CurrentPage}}" data-max="nomax" data-more="{{#More}}yes{{/More}}{{^More}}no{{/More}}"></div>
+<div class="pages" data-max="nomax">
+{{#Pages}}
+    {{#HasPrev}}
+    <a href="{{BasePath}}tag/{{TagName}}/page/{{PrevPage}}" rel="prev">&laquo; Back</a>
+    {{/HasPrev}}
+    <b>{{Page}}</b>
+    {{#HasNext}}
+    <a href="{{BasePath}}tag/{{TagName}}/page/{{NextPage}}" rel="next">Next &raquo;</a>
+    {{/HasNext}}
+{{/Pages}}
+</div>
 {{#ThreadList}}
 <hr />
 <article class="home-thread">
@@ -50,5 +60,15 @@
 {{/Tags}}
 </section>
 {{/ThreadList}}
-<div class="pages" data-current="{{CurrentPage}}" data-max="nomax" data-more="{{#More}}yes{{/More}}{{^More}}no{{/More}}"></div>
+<div class="pages" data-max="nomax">
+{{#Pages}}
+    {{#HasPrev}}
+    <a href="{{BasePath}}tag/{{TagName}}/page/{{PrevPage}}" rel="prev">&laquo; Back</a>
+    {{/HasPrev}}
+    <b>{{Page}}</b>
+    {{#HasNext}}
+    <a href="{{BasePath}}tag/{{TagName}}/page/{{NextPage}}" rel="next">Next &raquo;</a>
+    {{/HasNext}}
+{{/Pages}}
+</div>
 {{/Data}}

--- a/template/thread.html
+++ b/template/thread.html
@@ -9,8 +9,18 @@
 </nav>
 <hr />
 {{#Data}}
-<div class="pages" data-current="{{Page}}" data-max="{{MaxPages}}"></div>
 {{#Thread}}
+{{#Pages}}
+<div class="pages" data-current="{{Page}}" data-max="{{MaxPage}}">
+    {{#HasPrev}}
+    <a href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/page/{{PrevPage}}" rel="prev">&laquo; Back</a>
+    {{/HasPrev}}
+    <b>{{Page}}</b>
+    {{#HasNext}}
+    <a href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/page/{{NextPage}}" rel="next">Next &raquo;</a>
+    {{/HasNext}}
+</div>
+{{/Pages}}
 <section class="tags">
 {{#Tags}}<a href="{{BasePath}}tag/{{.}}" class="tag" rel="tag">#{{{.}}}</a> {{/Tags}}
 </section>
@@ -70,7 +80,17 @@
 </article>
 {{/Posts}}
 </div>
-<div class="pages" data-current="{{Page}}" data-max="{{MaxPages}}"></div>
+{{#Pages}}
+<div class="pages" data-current="{{Page}}" data-max="{{MaxPage}}">
+    {{#HasPrev}}
+    <a href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/page/{{PrevPage}}" rel="prev">&laquo; Back</a>
+    {{/HasPrev}}
+    <b>{{Page}}</b>
+    {{#HasNext}}
+    <a href="{{BasePath}}thread/{{#Thread}}{{ShortUrl}}{{/Thread}}/page/{{NextPage}}" rel="next">Next &raquo;</a>
+    {{/HasNext}}
+</div>
+{{/Pages}}
 <div id="quoted_posts" class="post"></div>
 <hr />
 <section class="form"><a name="reply" class="noborder"></a>

--- a/template/threads.html
+++ b/template/threads.html
@@ -28,11 +28,19 @@
             {{/Data}}{{/LastPost}}
         </a>
     </div>
-    <div class="right">
-        <a class="noborder hide" href="" onclick="Hiding.toggleHideThread('{{ShortUrl}}')">Hide</a>
-    </div>
+    <div class="right hiding" data-arg="{{ShortUrl}}"></div>
 </article>
 {{/Thread}}
 {{/Last}}
-<div class="pages" data-current="{{CurrentPage}}" data-max="nomax" data-more="{{#More}}yes{{/More}}{{^More}}no{{/More}}"></div>
+<div class="pages" data-max="nomax">
+{{#Pages}}
+    {{#HasPrev}}
+    <a href="{{BasePath}}threads/page/{{PrevPage}}" rel="prev">&laquo; Back</a>
+    {{/HasPrev}}
+    <b>{{Page}}</b>
+    {{#HasNext}}
+    <a href="{{BasePath}}threads/page/{{NextPage}}" rel="next">Next &raquo;</a>
+    {{/HasNext}}
+{{/Pages}}
+</div>
 {{/Data}}


### PR DESCRIPTION
* Il server si occupa di creare il `<div>` contenente i link alla pagina precedente e successiva (se necessario); se JS è abilitato lato client, laddove `data-max != 'nomax'`, il contenuto di questo `<div>` viene sostituito dalla lista fatta bene.
* I link `Hide` per thread e tag appaiono solamente se il client ha JS abilitato.
* In `handlers.go` ho messo un dot-import a "./data", così da non dover specificare ogni volta `data.XYZ`.