### PR TITLE
Site options hiding + quote button behaviour change + minifix shortify

### DIFF
--- a/src/main.go
+++ b/src/main.go
@@ -1,14 +1,15 @@
 package main
 
 import (
-	. "./data"
 	"flag"
-	"github.com/gorilla/mux"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
+
+	. "./data"
+	"github.com/gorilla/mux"
 )
 
 var (

--- a/static/src/coffee/editor.coffee
+++ b/static/src/coffee/editor.coffee
@@ -13,13 +13,11 @@ editorAdd = (elem, tag) ->
 
 quoteText = (elem) ->
 	txt = elem.parentElement.parentElement.text
-	if txt.selectionStart == txt.selectionEnd
+	unless window.getSelection()?.toString()?.length > 0
 		txt.value = txt.value[0..txt.selectionStart] + "> " + txt.value[txt.selectionStart+1..]
 		txt.focus()
 		return
-	txt.value = (if txt.selectionStart > 0 then txt.value[0..txt.selectionStart-1] else "") + "> " +
-		txt.value[txt.selectionStart..txt.selectionEnd].trim().replace(/\n/g, "\n> ") + "\n" +
-		txt.value[txt.selectionEnd+1..]
+	txt.value = "> #{window.getSelection()}"
 	txt.selectionStart = txt.selectionEnd = txt.value.length + 1
 	txt.focus()
 
@@ -36,7 +34,7 @@ document.getElementById('editorButtons')?.innerHTML = """
     <a onclick="Editor.add(this, 'html')">html</a>
     <a onclick="Editor.add(this, 'video')">video</a>
     <a onclick="Editor.add(this, 'pre')">pre</a>
-    <a onclick="Editor.quoteText(this)">&gt;</a>
+    <a onmousedown="Editor.quoteText(this)">&gt;</a>
 """
 
 window.Editor =

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -152,3 +152,6 @@ fromList(document.querySelectorAll('.postIdQuote')).map (e) ->
 			refId = if postNum == '0' then 'thread_quoted' else "p#{postNum}_quoted"
 			post = document.getElementById refId
 			post?.style.display = ''
+
+# Unhide siteoptions button
+document.getElementById('siteOptions')?.style.display = 'inline'

--- a/static/src/scss/screen.scss
+++ b/static/src/scss/screen.scss
@@ -68,6 +68,10 @@ nav.upper {
 
 img.head { width: 100%; max-width: 410px; margin-top: 10px; }
 
+span#siteOptions {
+	display: none;
+}
+
 table.blacklist {
 	margin-top: 0.5em;
 	th, td { padding: 0.2em 0.5em; }

--- a/template/layout.html
+++ b/template/layout.html
@@ -57,23 +57,25 @@
             <a href="//{{#Info}}{{FullVersionDomain}}{{/Info}}{{UrlPath}}" style="box-shadow: 0 0 0 1px green inset;" rel="alternate">EXIT LIGHT VERSION</a>
     {{/IsLight}}
             <a id="safeBtn" href="#">SAFE MODE</a>
-            <a href="#overlay" style="box-shadow: 0 0 0 1px #777 inset;" onclick='OptionUtils.showOptions()'>SITE OPTIONS</a>
-            <div id="overlay">
-                <div>
-                    <h2>Site options</h2>
-                    <form action="javascript:void(0)" onchange="OptionUtils.reloadOptions()">
-                        <input name="option" type="checkbox" id="dehighlight" checked/>
-                        <label for="dehighlight">De-highlight already viewed threads</label>
-                        <input name="option" type="checkbox" id="jumptolastread" checked>
-                        <label for="jumptolastread">Make 'last reply' link point to latest read post</label>
-                        <input name="option" type="checkbox" id="anonizeAll">
-                        <label for="anonizeAll">Make every user anonymous (hide names/tripcodes)</label>
-                        <input name="option" type="checkbox" id="useProxy">
-                        <label for="useProxy">Use enhanced security (see stiki page)</label>
-                    </form>
-                    <a href="#overlay" class="button" style="border: 1px solid #ccc; padding: 0.1em 1em;" onclick='OptionUtils.showOptions()'>Exit</a>
+            <span id="siteOptions">
+                <a href="#overlay" style="box-shadow: 0 0 0 1px #777 inset;" onclick='OptionUtils.showOptions()'>SITE OPTIONS</a>
+                <div id="overlay">
+                    <div>
+                        <h2>Site options</h2>
+                        <form action="javascript:void(0)" onchange="OptionUtils.reloadOptions()">
+                            <input name="option" type="checkbox" id="dehighlight" checked/>
+                            <label for="dehighlight">De-highlight already viewed threads</label>
+                            <input name="option" type="checkbox" id="jumptolastread" checked/>
+                            <label for="jumptolastread">Make 'last reply' link point to latest read post</label>
+                            <input name="option" type="checkbox" id="anonizeAll"/>
+                            <label for="anonizeAll">Make every user anonymous (hide names/tripcodes)</label>
+                            <input name="option" type="checkbox" id="useProxy"/>
+                            <label for="useProxy">Use enhanced security (see stiki page)</label>
+                        </form>
+                        <a href="#overlay" class="button" style="border: 1px solid #ccc; padding: 0.1em 1em;" onclick='OptionUtils.showOptions()'>Exit</a>
+                    </div>
                 </div>
-            </div>
+            </span>
     </nav></footer>
     <script src="/static/lib/qwest.min.js"></script>
     <script src="/static/lib/cookies.min.js"></script>


### PR DESCRIPTION
Ti faccio revieware i commit perché sono stanco morto e potrei aver scritto cagate...vedi #86

Edit: ho aggiunto un commit che sistema un problema di shortify che si presenta attualmente ad esempio [qui](https://crunchy.rocks/tag/%23crunchy+rocks): se il post break è fatto a metà di una tag, questa non viene chiusa correttamente. Il nuovo comportamento è droppare tutta la tag in questione e chiudere quelle rimaste sullo stack.

P.S. se vedi che gli import cambiano ordine è perché ho messo il plugin `goimports` al posto di `gofmt`, e ha uno stile diverso che mette separati tutti gli import non standard.