### PR TITLE
Fix a bunch of admin-related bugs, change tagsearch behaviour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
 all: maud
 
-maud: grunt dep
+maud: grunt dep core
+
+.PHONY: core
+core:
 	go install github.com/hamcha/maud/maud
 
 grunt:

--- a/maud/handlers.go
+++ b/maud/handlers.go
@@ -760,7 +760,7 @@ func httpVars(rw http.ResponseWriter, req *http.Request) {
 		return
 	}
 	rw.Header().Set("Content-Type", "application/javascript")
-	fmt.Fprintln(rw, "window.crOpts = "+string(jsonVars))
+	fmt.Fprintf(rw, "window.crOpts = %s;\nObject.freeze(window.crOpts);\n", string(jsonVars))
 }
 
 func sendCSPHeaders(rw http.ResponseWriter, req *http.Request) {

--- a/static/images/nosec.svg
+++ b/static/images/nosec.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 viewBox="0 0 96.3 64" enable-background="new 0 0 96.3 64" xml:space="preserve">
+<g>
+	<path fill="#ff4747" d="M35.2,27H34v-6.1c0-6.3-5.5-11.5-12.5-11.5C14.5,9.4,9,14.6,9,20.9V27H8c-2.5,0-4,1.1-4,3.4v19.5   C4,52.1,5.6,54,8,54h27.2c2.5,0,4.8-1.9,4.8-4.1V30.4C40,28.1,37.7,27,35.2,27z M28,27H15v-6.1c0-3.3,2.8-6.1,6.5-6.1   c3.7,0,6.5,2.7,6.5,6.1V27z"/>
+	<rect fill="none" stroke-width="3" stroke="#ff4747" width="10.891071" height="45.283932" x="66.358002" y="-47.305473" transform="matrix(0.70710678,0.70710678,-0.70710678,0.70710678,0,0)" />
+	<rect fill="none" stroke-width="3" stroke="#ff4747" width="10.891071" height="45.283932" x="-30.109039" y="-94.445503" transform="matrix(-0.70710678,0.70710678,-0.70710678,-0.70710678,0,0)" />
+</g>
+</svg>

--- a/static/images/sec.svg
+++ b/static/images/sec.svg
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<!-- Generator: Adobe Illustrator 18.0.0, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
 <!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
 <svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
 	 viewBox="0 0 96.3 64" enable-background="new 0 0 96.3 64" xml:space="preserve">

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -111,7 +111,10 @@ if toggleForm?
 
 # Unhide post actions to admins
 if window.crOpts.adminMode
-	con.className += " inlineBlock" for con in document.querySelectorAll ".postactions"
+	for con in document.querySelectorAll ".postactions"
+		con.classList.remove 'unavailable'
+		console.log con.classList
+		con.classList.add 'inlineBlock'
 
 # Setup onhover event for postIdQuote
 fromList(document.querySelectorAll('.postIdQuote')).map (e) ->

--- a/static/src/coffee/fixes.coffee
+++ b/static/src/coffee/fixes.coffee
@@ -113,7 +113,6 @@ if toggleForm?
 if window.crOpts.adminMode
 	for con in document.querySelectorAll ".postactions"
 		con.classList.remove 'unavailable'
-		console.log con.classList
 		con.classList.add 'inlineBlock'
 
 # Setup onhover event for postIdQuote

--- a/static/src/coffee/options.coffee
+++ b/static/src/coffee/options.coffee
@@ -34,8 +34,13 @@ if opts?
 		return unless opt.id?
 		opt.checked = window.SiteOptions[opt.id]
 	# Enable lock-tick if using proxy
-	if Cookies.get('crUseProxy') and location.protocol is 'https:'
-		document.getElementById('secureSign').style.visibility = 'visible'
+	if Cookies.get('crUseProxy')
+		sign = document.getElementById('secureSign')
+		if location.protocol isnt 'https:'
+			img = sign.querySelector('img')
+			img.src = img.src[..-8] + "nosec.svg"
+			img.alt = 'Enchanced Security requested, but protocol is not HTTPS'
+		sign.style.visibility = 'visible'
 else
 	# likely the first time visiting the site
 	window.SiteOptions = reloadOptions()

--- a/static/src/coffee/options.coffee
+++ b/static/src/coffee/options.coffee
@@ -34,7 +34,7 @@ if opts?
 		return unless opt.id?
 		opt.checked = window.SiteOptions[opt.id]
 	# Enable lock-tick if using proxy
-	if Cookies.get 'crUseProxy'
+	if Cookies.get('crUseProxy') and location.protocol is 'https:'
 		document.getElementById('secureSign').style.visibility = 'visible'
 else
 	# likely the first time visiting the site

--- a/static/src/coffee/threads.coffee
+++ b/static/src/coffee/threads.coffee
@@ -17,10 +17,10 @@ markAllRead = ->
 		window.localStorage.setItem "lview_#{surl}", "#{date}##{lpost}##{lpage}"
 
 pageIs =
-	thread: window.location.pathname[1...8] == 'thread/'
-	threads: window.location.pathname[1...8] == 'threads'
-	tagSearch: window.location.pathname[1...5] == 'tag/'
-	home: window.location.pathname == '/'
+	thread:    window.location.pathname[...8] == "#{window.crOpts.basepath}thread/"
+	threads:   window.location.pathname[...8] == "#{window.crOpts.basepath}threads"
+	tagSearch: window.location.pathname[...5] == "#{window.crOpts.basepath}tag/"
+	home:      window.location.pathname == window.crOpts.basepath
 
 # mark NSFW threads
 if pageIs.tagSearch or pageIs.threads or pageIs.home

--- a/static/src/coffee/threads.coffee
+++ b/static/src/coffee/threads.coffee
@@ -2,6 +2,8 @@
 
 return unless window.localStorage?
 
+stripBasepath = (s) -> s[window.crOpts.basepath.length..]
+
 markAllRead = ->
 	window.fromList(document.querySelectorAll 'article.thread-item').map (thread) ->
 		date = thread.querySelector('span.date').dataset.udate
@@ -14,12 +16,13 @@ markAllRead = ->
 		else
 			lpost = lpost[2..] # strip the initial "#p"
 		lpage = '1' unless lpage?
+		console.log "saving lview_#{surl}"
 		window.localStorage.setItem "lview_#{surl}", "#{date}##{lpost}##{lpage}"
 
 pageIs =
-	thread:    window.location.pathname[...8] == "#{window.crOpts.basepath}thread/"
-	threads:   window.location.pathname[...8] == "#{window.crOpts.basepath}threads"
-	tagSearch: window.location.pathname[...5] == "#{window.crOpts.basepath}tag/"
+	thread:    window.location.pathname.startsWith "#{window.crOpts.basepath}thread/"
+	threads:   window.location.pathname.startsWith "#{window.crOpts.basepath}threads"
+	tagSearch: window.location.pathname.startsWith "#{window.crOpts.basepath}tag/"
 	home:      window.location.pathname == window.crOpts.basepath
 
 # mark NSFW threads
@@ -59,7 +62,7 @@ if pageIs.thread
 	date = latest.querySelector('a.date').dataset.udate
 	# id of latest post
 	if date?
-		surl = window.location.pathname.split('/')[2]
+		surl = stripBasepath(window.location.pathname).split('/')[1]
 		window.localStorage.setItem "lview_#{surl}", "#{date}##{npost}##{page}"
 else if pageIs.home or pageIs.threads
 	# Bind "Mark All Read" button
@@ -71,8 +74,8 @@ else if pageIs.home or pageIs.threads
 		date = thread.querySelector('span.date').dataset.udate
 		# compare with locally saved date, if any
 		lreplyAnchor = thread.querySelector 'a.last-reply'
-		splpath = lreplyAnchor.pathname.split '/'
-		surl = splpath[2]
+		splpath = stripBasepath(lreplyAnchor.pathname).split('/')
+		surl = splpath[1]
 		item = window.localStorage.getItem "lview_#{surl}"
 		return unless item?
 		[lview, lpost, lpage] = item.split '#'
@@ -85,5 +88,5 @@ else if pageIs.home or pageIs.threads
 			if SiteOptions.jumptolastread
 				if splpath.length > 3 and lpage?
 					# pathname contains /page/n
-					lreplyAnchor.pathname = splpath[0..2].join('/') + "/page/#{lpage}"
+					lreplyAnchor.pathname = splpath[0..1].join('/') + "/page/#{lpage}"
 				lreplyAnchor.hash = if lpost is 0 then "#thread" else "#p#{lpost}"

--- a/static/src/scss/screen.scss
+++ b/static/src/scss/screen.scss
@@ -462,9 +462,12 @@ input.inline { display: inline-block; padding: 3px; margin-right: 5px; }
 		font-weight: 900;
 		margin: 0;
 		padding: 0;
+		padding-right: 150px;
 		width: 100%;
+		max-height: 150px;
 		box-sizing: border-box;
 		text-align: center;
+		overflow: hidden;
 	}
 }
 

--- a/template/home.html
+++ b/template/home.html
@@ -21,8 +21,8 @@
 <article class="thread-item thread" data-tags="{{#Tags}}#{{{.}}}{{/Tags}}">
     <h3 class="thread-name"><a href="{{BasePath}}thread/{{ShortUrl}}" class="nolink">{{Title}}</a></h3>
     <div>Last reply:
-		<a class="last-reply" href="{{BasePath}}thread/{{ShortUrl}}/page/{{Page}}#p{{LastMessage}}">
-			#{{LastMessage}} -
+        <a class="last-reply" href="{{BasePath}}thread/{{ShortUrl}}/page/{{Page}}#p{{LastMessage}}">
+            #{{LastMessage}} -
             {{#LastPost}}{{#Data}}
             {{#Author}}
             <span class="nickname">{{Nickname}}</span>

--- a/template/layout.html
+++ b/template/layout.html
@@ -72,7 +72,7 @@
     </nav></footer>
     <script src="/static/lib/qwest.min.js"></script>
     <script src="/static/lib/cookies.min.js"></script>
-    <script src="/vars.js"></script>
+    <script src="{{BasePath}}vars.js"></script>
     <script src="/static/js/utils.js"></script>
     <script src="/static/js/options.js"></script>
     <script src="/static/js/fixes.js"></script>


### PR DESCRIPTION
Sono un po' di modifiche, ho cercato di separarle in commit isolati per chiarezza. In a nutshell:

1. Vari script non consideravano come si deve `crOpts.basepath`, quindi in admin mode attivata tramite path c'era una serie di bug principalmente correlati a `option.coffee` (quindi ad esempio il thread dehighlighting, il jump to last read, eccetera)  
2. I pulsanti di post action venivano nascosti anche all'admin se il post era già stato deletato dall'utente, rendendo impossibile purgare un post/thread. Era solo un frontend bug, quindi di facile soluzione.  
3. Ho aggiunto un'immagine per indicare quando l'utente ha attivato enhanced security ma sta visitando il sito da http (su crunchy.rocks non può succedere, ma in generale sì)  
4. `window.crOpts` è ora read-only
5. ho deciso di modificare il comportamento del search by tag quando vengono specificate più tag: prima trovava tutti i thread con una qualunque delle tag specificate, ora invece trova solo i thread che hanno *tutte* le tag specificate.